### PR TITLE
Fix major typo

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -9,7 +9,7 @@ from typing import Optional, Dict, Any, List, Union, Type
 from pyatlan.model.assets import Asset
 from pyatlan.model.lineage import LineageDirection
 
-mcp = FastMCP("Altan MCP", dependencies=["pyatlan"])
+mcp = FastMCP("Atlan MCP", dependencies=["pyatlan"])
 
 
 @mcp.tool()


### PR DESCRIPTION
Changed 'Altan MCP' to 'Atlan MCP'
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/b49855d3-96ef-40e6-8a3d-73291c898428" />
