### PR TITLE
feat: add atlan mcp agent tracking

### DIFF
--- a/modelcontextprotocol/settings.py
+++ b/modelcontextprotocol/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
         return {
             "x-atlan-agent": self.ATLAN_AGENT,
             "x-atlan-agent-id": self.ATLAN_AGENT_ID,
+            "x-atlan-client-origin": self.ATLAN_AGENT,
         }
 
     class Config:


### PR DESCRIPTION
Adds tracking headers to all Atlan API requests made using the MCP server