### PR TITLE
feat: add update assets tool

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -9,6 +9,7 @@ The Atlan [Model Context Protocol](https://modelcontextprotocol.io/introduction)
 | `search_assets`       | Search for assets based on conditions |
 | `get_assets_by_dsl`   | Retrieve assets using a DSL query |
 | `traverse_lineage`    | Retrieve lineage for an asset |
+| `update_assets`       | Update asset attributes (user description and certificate status) |
 
 ## Installation
 

--- a/modelcontextprotocol/settings.py
+++ b/modelcontextprotocol/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
         return {
             "x-atlan-agent": self.ATLAN_AGENT,
             "x-atlan-agent-id": self.ATLAN_AGENT_ID,
+            "x-atlan-client-origin": self.ATLAN_AGENT,
         }
 
     class Config:


### PR DESCRIPTION
Add `update_assets` tool that will allow agents to update `userDescription` and `certificateStatus` of assets discovered using other tools