### PR TITLE
Fix Lineage Tool

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -287,11 +287,11 @@ def traverse_lineage_tool(
         )
 
     return traverse_lineage(
-        guid=guid,
+        guid=str(guid),
         direction=direction_enum,
-        depth=depth,
-        size=size,
-        immediate_neighbors=immediate_neighbors,
+        depth=int(depth),
+        size=int(size),
+        immediate_neighbors=bool(immediate_neighbors),
     )
 
 


### PR DESCRIPTION
Issue:
```
traverse_lineage_tool
Request

{
  `guid`: `ee122ef3-c407-479a-91bc-3673074e0d9d`,
  `size`: `20`,
  `depth`: `3`,
  `direction`: `UPSTREAM`
}
Response

{
  "assets": [],
  "error": "ATLAN-PYTHON-400-048 Invalid parameter type for depth should be int. Suggestion: Check that you have used the correct type of parameter."
}
```


Fix:

![image](https://github.com/user-attachments/assets/7cf83871-8c02-4ed9-94e8-8963eafa47b3)
