### PR TITLE
Fix: CI and Release

### DIFF
--- a/.github/workflows/mcp-server-release.yml
+++ b/.github/workflows/mcp-server-release.yml
@@ -1,28 +1,26 @@
 name: MCP-Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
-    paths:
-      - 'modelcontextprotocol/version.py'
 
 jobs:
-  release:
+  prepare-release:
+    # Only run when a PR with the "release" label is merged
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      should_release: ${{ steps.check_tag.outputs.exists == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
 
       - name: Get version
         id: get_version
@@ -53,95 +51,66 @@ jobs:
 
           echo "Generating changelog for version $VERSION ($RELEASE_DATE)"
 
-          # Get the previous version tag
-          PREV_TAG=$(git tag -l "v*" --sort=-v:refname | head -n 1)
+          # Get the previous version tag. If this is the first release, PREV_TAG will be empty.
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || git rev-list --max-parents=0 HEAD)
+
           if [ -z "$PREV_TAG" ]; then
             # If no previous tag, use root commit
             PREV_COMMIT=$(git rev-list --max-parents=0 HEAD)
-            RANGE="$PREV_COMMIT..HEAD"
+            RANGE="$PREV_COMMIT..${{ github.event.pull_request.head.sha }}"
+            echo "No previous tag found. Using range from first commit to PR head SHA: $RANGE"
+          elif git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            RANGE="$PREV_TAG..${{ github.event.pull_request.head.sha }}"
+            echo "Previous tag found: $PREV_TAG. Using range from previous tag to PR head SHA: $RANGE"
           else
-            RANGE="$PREV_TAG..HEAD"
+             # Fallback if PREV_TAG is not a valid ref (e.g. very first release after this script is introduced)
+            PREV_COMMIT=$(git rev-list --max-parents=0 HEAD) # Or consider GITHUB_SHA of the commit before the merge
+            RANGE="$PREV_COMMIT..${{ github.event.pull_request.head.sha }}"
+            echo "PREV_TAG $PREV_TAG was not a valid ref. Using range from first commit to PR head SHA: $RANGE"
           fi
 
-          echo "Using commit range: $RANGE"
+          echo "Using commit range for RELEASE_NOTES.md: $RANGE"
 
-          # Create temporary changelog entry
-          echo -e "## [$VERSION] - $RELEASE_DATE\n" > temp_changelog.md
+          # Create temporary changelog entry for RELEASE_NOTES.md
+          echo -e "## [$VERSION] - $RELEASE_DATE\n" > RELEASE_NOTES.md
 
           # Add features
-          git log $RANGE --format="* %s (%h)" | grep -E "^* feat|^* feature" 2>/dev/null | sed -E 's/^* feat(ure)?//' > features.txt
+          git log $RANGE --format="* %s (%h)" --grep="^feat" --perl-regexp --no-merges 2>/dev/null | sed -E 's/^\* feat(\(.+\))?:?\s*//' > features.txt
           if [ -s features.txt ]; then
-            echo -e "### Added\n" >> temp_changelog.md
-            cat features.txt >> temp_changelog.md
-            echo -e "\n" >> temp_changelog.md
+            echo -e "### Added\n" >> RELEASE_NOTES.md
+            cat features.txt >> RELEASE_NOTES.md
+            echo -e "\n" >> RELEASE_NOTES.md
           fi
 
           # Add fixes
-          git log $RANGE --format="* %s (%h)" | grep "^* fix" 2>/dev/null | sed 's/^* fix//' > fixes.txt
+          git log $RANGE --format="* %s (%h)" --grep="^fix" --perl-regexp --no-merges 2>/dev/null | sed 's/^\* fix(\(.+\))?:?\s*//' > fixes.txt
           if [ -s fixes.txt ]; then
-            echo -e "### Fixed\n" >> temp_changelog.md
-            cat fixes.txt >> temp_changelog.md
-            echo -e "\n" >> temp_changelog.md
+            echo -e "### Fixed\n" >> RELEASE_NOTES.md
+            cat fixes.txt >> RELEASE_NOTES.md
+            echo -e "\n" >> RELEASE_NOTES.md
           fi
 
-          # Add other changes
-          git log $RANGE --format="* %s (%h)" | grep -v -E "^* feat|^* feature|^* fix" 2>/dev/null > others.txt
+          # Add other changes (excluding merge commits, chore, docs, style, refactor, test, ci)
+          git log $RANGE --format="* %s (%h)" --no-merges | grep -v -E "^\* (feat|fix|chore|docs|style|refactor|test|ci)(\(.+\))?:?\s*" 2>/dev/null > others.txt
           if [ -s others.txt ]; then
-            echo -e "### Changed\n" >> temp_changelog.md
-            cat others.txt >> temp_changelog.md
-            echo -e "\n" >> temp_changelog.md
+            echo -e "### Changed\n" >> RELEASE_NOTES.md
+            cat others.txt >> RELEASE_NOTES.md
+            echo -e "\n" >> RELEASE_NOTES.md
           fi
 
-          # If no changes found, add a simple entry
+          # If no specific changes found, add a simple entry
           if [ ! -s features.txt ] && [ ! -s fixes.txt ] && [ ! -s others.txt ]; then
-            echo "- Release version $VERSION" >> temp_changelog.md
+            echo "- Release version $VERSION" >> RELEASE_NOTES.md
           fi
-
-          # Add new version at the top (after header section but before the first version)
-          echo "Updating CHANGELOG.md with new version"
-
-          # Create a simpler approach that works reliably
-          {
-            # Extract the header part (everything before the first version)
-            sed -n '/^# Changelog/,/^## \[/p' CHANGELOG.md | sed '$d' > header.tmp
-
-            # Prepend new version after header
-            cat header.tmp > CHANGELOG.md.new
-            cat temp_changelog.md >> CHANGELOG.md.new
-            echo "" >> CHANGELOG.md.new
-
-            # Append existing versions
-            sed -n '/^## \[/,$p' CHANGELOG.md >> CHANGELOG.md.new
-
-            # Replace the original file
-            cp CHANGELOG.md.new CHANGELOG.md
-          } || {
-            # Fallback if the above fails
-            echo "Using simplified approach"
-            (cat temp_changelog.md; echo ""; cat CHANGELOG.md) > CHANGELOG.md.new
-            cp CHANGELOG.md.new CHANGELOG.md
-          }
-
-          # Also save for release notes
-          cp temp_changelog.md RELEASE_NOTES.md || echo "Failed to create RELEASE_NOTES.md"
 
           # Clean up temporary files
-          rm -f temp_changelog.md features.txt fixes.txt others.txt header.tmp CHANGELOG.md.new
+          rm -f features.txt fixes.txt others.txt
 
-          echo "Changelog generation completed"
+          echo "RELEASE_NOTES.md generation completed."
 
           # Show result for debugging
-          echo "Updated CHANGELOG.md contents:"
-          cat CHANGELOG.md
-
-      - name: Commit changelog update
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git add CHANGELOG.md
-          git commit -m "docs: update changelog for version ${{ steps.get_version.outputs.version }} [skip ci]"
-          git push
+          echo "RELEASE_NOTES.md contents:"
+          cat RELEASE_NOTES.md
 
       - name: Create Tag
         if: steps.check_tag.outputs.exists == 'false'
@@ -151,32 +120,49 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           body_path: RELEASE_NOTES.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python for Build
+      # Upload release notes for other jobs to use
+      - name: Upload release notes
         if: steps.check_tag.outputs.exists == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: RELEASE_NOTES.md
+          retention-days: 1
+
+  publish-pypi:
+    needs: prepare-release
+    if: needs.prepare-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.prepare-release.outputs.version }}
+
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Install build dependencies
-        if: steps.check_tag.outputs.exists == 'false'
         run: |
           python -m pip install --upgrade pip
           pip install build wheel twine
 
       - name: Build package
-        if: steps.check_tag.outputs.exists == 'false'
         run: |
           cd modelcontextprotocol
           python -m build
 
       - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists == 'false'
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -184,12 +170,23 @@ jobs:
           cd modelcontextprotocol
           twine upload dist/*
 
+  publish-docker:
+    needs: prepare-release
+    if: needs.prepare-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.prepare-release.outputs.version }}
+
       - name: Set up Docker Buildx
-        if: steps.check_tag.outputs.exists == 'false'
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        if: steps.check_tag.outputs.exists == 'false'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -197,11 +194,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        if: steps.check_tag.outputs.exists == 'false'
         uses: docker/build-push-action@v5
         with:
           context: ./modelcontextprotocol/
           push: true
           tags: |
             ghcr.io/atlanhq/atlan-mcp-server:latest
-            ghcr.io/atlanhq/atlan-mcp-server:${{ steps.get_version.outputs.version }}
+            ghcr.io/atlanhq/atlan-mcp-server:${{ needs.prepare-release.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-05-17
+
 ### Added
-- Initial project setup
+- Support for new transport modes: streamable HTTP and SSE
+- MCP server executable script (`atlan-mcp-server`)
+- Improved Docker image with non-root user and security enhancements
+
+### Changed
+- Made MCP server an installable package
+- Updated dependencies and bumped versions
+- Improved build process for faster Docker builds
+- Restructured release workflow for better isolation and PR-based releases
+
+### Fixed
+- Various minor bugs and stability issues
+
+### Documentation
+- Updated setup and usage instructions
+- Added more comprehensive examples
+
 
 ## [0.1.0] - 2024-05-05
-- Initial release
+
+### Added
+- Initial release of Atlan MCP Server
+- Basic functionality for integrating with Atlan


### PR DESCRIPTION
ci: restructure release workflow for better isolation and PR-based releases

- Change workflow trigger to run on merged PRs with 'release' label instead of direct pushes
- Split monolithic job into three separate jobs: prepare-release, publish-pypi, and publish-docker
- Add job dependencies to ensure proper execution order
- Pass version information between jobs using outputs
- Set appropriate permissions for each job
- Remove automatic CHANGELOG.md commit and push to main
- Improve release notes generation from commits


Note: it follows similar approach as our app-sdk does.