### PR TITLE
Attributes in doc string for LLM context

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -202,6 +202,12 @@ def search_assets_tool(
             include_attributes=["categories"]
         )
 
+    Additional attributes you can include in the conditions to extract more metadata from an asset:
+        - columns
+        - column_count
+        - row_count
+        - readme
+        - owner_users
     """
     try:
         # Parse JSON string parameters if needed


### PR DESCRIPTION
This pull request adds support for extracting additional metadata attributes in the `search_assets_tool` function within `modelcontextprotocol/server.py`.

Metadata extraction enhancements:

* [`modelcontextprotocol/server.py`](diffhunk://#diff-ff695b73f10f2a8b20223a7fe7ddc34b6560080412603326f5e89aeffa57f3a9R205-R210): Updated the docstring for `search_assets_tool` to include new attributes (`columns`, `column_count`, `row_count`, `readme`, `owner_users`) that can be used to extract more metadata from an asset.