### PR TITLE
Add: DeepWiki Docs Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ An MCP server that enables interaction with Atlan services through tool calling.
 
 You can find the documentation and setup instructions for the MCP server [here](modelcontextprotocol/README.md).
 
+
 ## 🔍 DeepWiki: Ask Questions About This Project
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/atlanhq/agent-toolkit)
 
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to the Atlan Agent Toolkit.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ An MCP server that enables interaction with Atlan services through tool calling.
 
 You can find the documentation and setup instructions for the MCP server [here](modelcontextprotocol/README.md).
 
+## 🔍 DeepWiki: Ask Questions About This Project
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/atlanhq/agent-toolkit)
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to the Atlan Agent Toolkit.


### PR DESCRIPTION
## Changes Summary
- Add DeepWiki Docs Link in `README.md` file
- On DeepWiki -> Latest re-indexing done for `atlanhq/agent-toolkit` on July 15, 2025
- Closes #97 