### PR TITLE
Tool Access Control

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -147,6 +147,102 @@ Open `Cursor > Settings > Tools & Integrations > New MCP Server` to include the 
 | `create_glossary_categories` | Create glossary categories                               |
 | `create_glossary_terms` | Create glossary terms                                         |
 
+## Tool Access Control
+
+The Atlan MCP Server includes a configurable tool restriction middleware that allows you to control which tools are available to users. This is useful for implementing role-based access control or restricting certain operations in specific environments.
+
+### Restricting Tools
+
+You can restrict access to specific tools using the `RESTRICTED_TOOLS` environment variable. Provide a comma-separated list of tool names that should be blocked:
+
+#### Docker Configuration
+
+```json
+{
+  "mcpServers": {
+    "atlan": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ATLAN_API_KEY=<YOUR_API_KEY>",
+        "-e",
+        "ATLAN_BASE_URL=https://<YOUR_INSTANCE>.atlan.com",
+        "-e",
+        "ATLAN_AGENT_ID=<YOUR_AGENT_ID>",
+        "-e",
+        "RESTRICTED_TOOLS=get_assets_by_dsl_tool,update_assets_tool",
+        "ghcr.io/atlanhq/atlan-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+#### uv Configuration
+
+```json
+{
+  "mcpServers": {
+    "atlan": {
+      "command": "uvx",
+      "args": ["atlan-mcp-server"],
+      "env": {
+        "ATLAN_API_KEY": "<YOUR_API_KEY>",
+        "ATLAN_BASE_URL": "https://<YOUR_INSTANCE>.atlan.com",
+        "ATLAN_AGENT_ID": "<YOUR_AGENT_ID>",
+        "RESTRICTED_TOOLS": "get_assets_by_dsl_tool,update_assets_tool"
+      }
+    }
+  }
+}
+```
+
+### Available Tool Names for Restriction
+
+You can restrict any of the following tools:
+
+- `search_assets_tool` - Asset search functionality
+- `get_assets_by_dsl_tool` - DSL query execution
+- `traverse_lineage_tool` - Lineage traversal
+- `update_assets_tool` - Asset updates (descriptions, certificates)
+- `create_glossaries` - Glossary creation
+- `create_glossary_categories` - Category creation
+- `create_glossary_terms` - Term creation
+
+### Common Use Cases
+
+#### Read-Only Access
+Restrict all write operations:
+```
+RESTRICTED_TOOLS=update_assets_tool,create_glossaries,create_glossary_categories,create_glossary_terms
+```
+
+#### Disable DSL Queries
+For security or performance reasons:
+```
+RESTRICTED_TOOLS=get_assets_by_dsl_tool
+```
+
+#### Minimal Access
+Allow only basic search:
+```
+RESTRICTED_TOOLS=get_assets_by_dsl_tool,update_assets_tool,traverse_lineage_tool,create_glossaries,create_glossary_categories,create_glossary_terms
+```
+
+### How It Works
+
+When tools are restricted:
+1. **Hidden from listings**: Restricted tools won't appear when clients request available tools
+2. **Execution blocked**: If someone tries to execute a restricted tool, they'll receive a clear error message
+3. **Logged**: All access decisions are logged for monitoring and debugging
+
+### No Restrictions (Default)
+
+If you don't set the `RESTRICTED_TOOLS` environment variable, all tools will be available by default.
+
 ## Production Deployment
 
 - Host the Atlan MCP container image on the cloud/platform of your choice

--- a/modelcontextprotocol/middleware.py
+++ b/modelcontextprotocol/middleware.py
@@ -1,0 +1,160 @@
+"""
+Tool restriction middleware for FastMCP to control tool access.
+
+This middleware restricts access to specified tools based on configuration.
+Tools can be restricted globally by providing a list during initialization.
+"""
+
+from typing import List, Set, Optional
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.exceptions import ToolError
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ToolRestrictionMiddleware(Middleware):
+    """
+    Middleware to restrict tool access based on configuration.
+
+    Allows specifying which tools should be restricted during initialization.
+    Restricted tools will be hidden from the tools list and blocked from execution.
+    """
+
+    def __init__(self, restricted_tools: Optional[List[str]] = None):
+        """
+        Initialize the Tool Restriction Middleware.
+
+        Args:
+            restricted_tools: List of tool names to restrict. If None, no tools are restricted.
+        """
+        self.restricted_tools: Set[str] = set(restricted_tools or [])
+        self._log_initialization()
+
+    def _log_initialization(self) -> None:
+        """Log middleware initialization details."""
+        logger.info(
+            f"Tool Restriction Middleware initialized with {len(self.restricted_tools)} restricted tools",
+            restricted_tools=list(self.restricted_tools),
+        )
+
+    def _is_tool_restricted(self, tool_name: str) -> bool:
+        """
+        Check if a tool is restricted.
+
+        Args:
+            tool_name: Name of the tool being called.
+
+        Returns:
+            True if the tool is restricted, False otherwise.
+        """
+        is_restricted = tool_name in self.restricted_tools
+
+        if is_restricted:
+            logger.info(f"Tool {tool_name} is restricted", tool=tool_name)
+
+        return is_restricted
+
+    def _get_error_message(self, tool_name: str) -> str:
+        """
+        Get appropriate error message for a restricted tool.
+
+        Args:
+            tool_name: Name of the restricted tool.
+
+        Returns:
+            Error message string.
+        """
+        return f"Tool '{tool_name}' is not available due to access restrictions"
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next):
+        """
+        Hook called when a tool is being executed.
+
+        Checks if the tool is restricted and either allows execution or raises an error.
+
+        Args:
+            context: The middleware context containing request information.
+            call_next: Function to call the next middleware/handler in the chain.
+
+        Returns:
+            The result from the next handler if allowed.
+
+        Raises:
+            ToolError: If the tool is restricted.
+        """
+        tool_name = context.message.name
+
+        try:
+            # Check if tool is restricted
+            if self._is_tool_restricted(tool_name):
+                error_message = self._get_error_message(tool_name)
+
+                logger.warning(
+                    f"Tool access denied: {tool_name}",
+                    tool=tool_name,
+                    reason=error_message,
+                )
+
+                raise ToolError(error_message)
+
+            # Tool is allowed, proceed with execution
+            logger.debug(f"Tool access granted: {tool_name}", tool=tool_name)
+
+            return await call_next(context)
+
+        except ToolError:
+            # Re-raise ToolError as-is
+            raise
+        except Exception as e:
+            # Handle unexpected errors
+            logger.error(
+                f"Error in tool restriction middleware: {str(e)}",
+                tool=tool_name,
+                exc_info=True,
+            )
+            # Re-raise the original exception
+            raise
+
+    async def on_list_tools(self, context: MiddlewareContext, call_next):
+        """
+        Hook called when listing available tools.
+
+        Filters the tool list to hide restricted tools.
+
+        Args:
+            context: The middleware context.
+            call_next: Function to call the next handler.
+
+        Returns:
+            Filtered list of tools.
+        """
+        # Get the full list of tools
+        all_tools = await call_next(context)
+
+        try:
+            # If no tools are restricted, return all tools
+            if not self.restricted_tools:
+                return all_tools
+
+            # Filter out restricted tools
+            filtered_tools = [
+                tool for tool in all_tools if tool.name not in self.restricted_tools
+            ]
+
+            logger.debug(
+                "Filtered tool list",
+                total_tools=len(all_tools),
+                filtered_tools=len(filtered_tools),
+                restricted_tools=list(self.restricted_tools),
+            )
+
+            return filtered_tools
+
+        except Exception as e:
+            logger.error(
+                f"Error filtering tool list: {str(e)}",
+                exc_info=True,
+            )
+            # On error, return the original list to avoid breaking functionality
+            return all_tools

--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=2.8.1",
+    "fastmcp==2.11.0",
     "pyatlan>=6.0.1",
 ]
 

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -25,11 +25,6 @@ from middleware import ToolRestrictionMiddleware
 
 mcp = FastMCP("Atlan MCP Server", dependencies=["pyatlan", "fastmcp"])
 
-# Add tool restriction middleware
-# Configure which tools should be restricted
-# Can be set via environment variable RESTRICTED_TOOLS (comma-separated)
-# or by modifying the list below
-
 # Get restricted tools from environment variable or use default
 restricted_tools_env = os.getenv("RESTRICTED_TOOLS", "")
 if restricted_tools_env:
@@ -39,8 +34,6 @@ if restricted_tools_env:
 else:
     # Default configuration - modify this list to restrict specific tools
     restricted_tools = []
-    # Example: restrict DSL tool
-    # restricted_tools = ["get_assets_by_dsl_tool"]
 
 tool_restriction = ToolRestrictionMiddleware(restricted_tools=restricted_tools)
 mcp.add_middleware(tool_restriction)

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 from typing import Any, Dict, List
 from fastmcp import FastMCP
 from tools import (
@@ -19,8 +20,30 @@ from utils.parameters import (
     parse_json_parameter,
     parse_list_parameter,
 )
+from middleware import ToolRestrictionMiddleware
+
 
 mcp = FastMCP("Atlan MCP Server", dependencies=["pyatlan", "fastmcp"])
+
+# Add tool restriction middleware
+# Configure which tools should be restricted
+# Can be set via environment variable RESTRICTED_TOOLS (comma-separated)
+# or by modifying the list below
+
+# Get restricted tools from environment variable or use default
+restricted_tools_env = os.getenv("RESTRICTED_TOOLS", "")
+if restricted_tools_env:
+    restricted_tools = [
+        tool.strip() for tool in restricted_tools_env.split(",") if tool.strip()
+    ]
+else:
+    # Default configuration - modify this list to restrict specific tools
+    restricted_tools = []
+    # Example: restrict DSL tool
+    # restricted_tools = ["get_assets_by_dsl_tool"]
+
+tool_restriction = ToolRestrictionMiddleware(restricted_tools=restricted_tools)
+mcp.add_middleware(tool_restriction)
 
 
 @mcp.tool()


### PR DESCRIPTION
This pull request introduces a configurable tool restriction feature to the Atlan MCP Server, allowing administrators to control which tools are available to users. The feature is implemented via a new middleware and is documented in the `README.md`, enabling role-based access control or environment-specific restrictions. Configuration is supported through an environment variable, making it easy to manage tool access without code changes.

Tool restriction feature:

* Added `ToolRestrictionMiddleware` in `middleware.py` to block execution and hide restricted tools from listings, with clear error messages and logging for access decisions.
* Integrated the middleware into the MCP server in `server.py`, reading the `RESTRICTED_TOOLS` environment variable to determine which tools to restrict.
* Updated documentation in `README.md` to explain tool restriction, including configuration examples for Docker and uv, a list of available tools for restriction, and common use cases.

Dependency update:

* Updated `fastmcp` dependency version in `pyproject.toml` to `2.11.0` for compatibility with new middleware features.

General improvements:

* Added missing `os` import in `server.py` to support reading environment variables for tool restriction configuration.