### PR TITLE
added MCP transport mode docs readme 

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -245,31 +245,22 @@ If you don't set the `RESTRICTED_TOOLS` environment variable, all tools will be 
 
 ## Transport Modes
 
-The Atlan MCP Server supports three transport modes, each optimized for different deployment scenarios:
+The Atlan MCP Server supports three transport modes, each optimized for different deployment scenarios. For more details about MCP transport modes, see the [official MCP documentation](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
 
-### stdio (Default)
-- **Use case**: Local development, IDE integrations
-- **Benefits**: Simple, direct communication
-- **When to use**: Claude Desktop, Cursor IDE
+| Transport Mode | Use Case | Benefits | When to Use |
+|---|---|---|---|
+| **stdio** (Default) | Local development, IDE integrations | Simple, direct communication | Claude Desktop, Cursor IDE |
+| **SSE** (Server-Sent Events) | Remote deployments, web browsers | Real-time streaming, web-compatible | Cloud deployments, web clients |
+| **streamable-http** | HTTP-based remote connections | Standard HTTP, load balancer friendly | Kubernetes, containerized deployments |
 
-### SSE (Server-Sent Events)
-- **Use case**: Remote deployments, web browsers
-- **Benefits**: Real-time streaming, web-compatible
-- **When to use**: Cloud deployments, web clients
-
-### streamable-http
-- **Use case**: HTTP-based remote connections
-- **Benefits**: Standard HTTP, load balancer friendly
-- **When to use**: Kubernetes, containerized deployments
-
-For comprehensive deployment instructions, configuration examples, and production best practices, see our [Deployment Guide](./docs/DEPLOYMENT.md).
+For comprehensive deployment instructions, configuration examples, and production best practices, see our [Deployment Guide](./docs/Deployment.md).
 
 ## Production Deployment
 
 - Host the Atlan MCP container image on the cloud/platform of your choice
 - Make sure you add all the required environment variables
 - Choose the appropriate transport mode for your deployment scenario. SSE Transport is recommended for production (`-e MCP_TRANSPORT=sse`)
-- For detailed deployment scenarios and configurations, refer to the [Deployment Guide](./docs/DEPLOYMENT.md)
+- For detailed deployment scenarios and configurations, refer to the [Deployment Guide](./docs/Deployment.md)
 
 ### Remote MCP Configuration
 

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -268,7 +268,7 @@ For comprehensive deployment instructions, configuration examples, and productio
 
 - Host the Atlan MCP container image on the cloud/platform of your choice
 - Make sure you add all the required environment variables
-- Choose the appropriate transport mode for your deployment scenario
+- Choose the appropriate transport mode for your deployment scenario. SSE Transport is recommended for production (`-e MCP_TRANSPORT=sse`)
 - For detailed deployment scenarios and configurations, refer to the [Deployment Guide](./docs/DEPLOYMENT.md)
 
 ### Remote MCP Configuration

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -243,11 +243,33 @@ When tools are restricted:
 
 If you don't set the `RESTRICTED_TOOLS` environment variable, all tools will be available by default.
 
+## Transport Modes
+
+The Atlan MCP Server supports three transport modes, each optimized for different deployment scenarios:
+
+### stdio (Default)
+- **Use case**: Local development, IDE integrations
+- **Benefits**: Simple, direct communication
+- **When to use**: Claude Desktop, Cursor IDE
+
+### SSE (Server-Sent Events)
+- **Use case**: Remote deployments, web browsers
+- **Benefits**: Real-time streaming, web-compatible
+- **When to use**: Cloud deployments, web clients
+
+### streamable-http
+- **Use case**: HTTP-based remote connections
+- **Benefits**: Standard HTTP, load balancer friendly
+- **When to use**: Kubernetes, containerized deployments
+
+For comprehensive deployment instructions, configuration examples, and production best practices, see our [Deployment Guide](./docs/DEPLOYMENT.md).
+
 ## Production Deployment
 
 - Host the Atlan MCP container image on the cloud/platform of your choice
 - Make sure you add all the required environment variables
-- Make sure you start the server in the SSE transport mode `-e MCP_TRANSPORT=sse`
+- Choose the appropriate transport mode for your deployment scenario
+- For detailed deployment scenarios and configurations, refer to the [Deployment Guide](./docs/DEPLOYMENT.md)
 
 ### Remote MCP Configuration
 

--- a/modelcontextprotocol/docs/DEPLOYMENT.md
+++ b/modelcontextprotocol/docs/DEPLOYMENT.md
@@ -1,0 +1,79 @@
+# Atlan MCP Server Deployment Guide
+
+This guide covers transport modes and basic deployment options for the Atlan MCP Server.
+
+## Transport Modes
+
+The Atlan MCP Server supports three transport modes:
+
+### stdio (Default)
+- **Use case**: Local development, IDE integrations
+- **Benefits**: Simple, direct communication
+- **When to use**: Claude Desktop, Cursor IDE
+
+### SSE (Server-Sent Events)
+- **Use case**: Remote deployments, web browsers
+- **Benefits**: Real-time streaming, web-compatible
+- **When to use**: Cloud deployments, web clients
+
+### streamable-http
+- **Use case**: HTTP-based remote connections
+- **Benefits**: Standard HTTP, load balancer friendly
+- **When to use**: Kubernetes, containerized deployments
+
+## Basic Deployment Examples
+
+### Local Development (stdio)
+```bash
+# Default stdio mode
+python server.py
+
+# Or explicitly specify stdio
+python server.py --transport stdio
+```
+
+### Cloud Deployment (SSE)
+```bash
+# Docker with SSE
+docker run -d \
+  -p 8000:8000 \
+  -e ATLAN_API_KEY="<YOUR_API_KEY>" \
+  -e ATLAN_BASE_URL="https://<YOUR_INSTANCE>.atlan.com" \
+  -e MCP_TRANSPORT="sse" \
+  ghcr.io/atlanhq/atlan-mcp-server:latest
+
+# Python with SSE
+python server.py --transport sse --host 0.0.0.0 --port 8000
+```
+
+### HTTP Deployment (streamable-http)
+```bash
+# Docker with HTTP
+docker run -d \
+  -p 8000:8000 \
+  -e ATLAN_API_KEY="<YOUR_API_KEY>" \
+  -e ATLAN_BASE_URL="https://<YOUR_INSTANCE>.atlan.com" \
+  -e MCP_TRANSPORT="streamable-http" \
+  ghcr.io/atlanhq/atlan-mcp-server:latest
+
+# Python with HTTP
+python server.py --transport streamable-http --host 0.0.0.0 --port 8000
+```
+
+## Environment Variables
+
+### Required
+- `ATLAN_API_KEY`: Your Atlan API key
+- `ATLAN_BASE_URL`: Your Atlan instance URL
+
+### Transport Configuration
+- `MCP_TRANSPORT`: Transport mode (stdio/sse/streamable-http)
+- `MCP_HOST`: Host address for network transports (default: 0.0.0.0)
+- `MCP_PORT`: Port number for network transports (default: 8000)
+- `MCP_PATH`: Path for streamable-http transport (default: /)
+
+### Optional
+- `ATLAN_AGENT_ID`: Agent identifier
+- `RESTRICTED_TOOLS`: Comma-separated list of tools to restrict
+
+For additional support, refer to the main [README](../README.md) or contact support@atlan.com.

--- a/modelcontextprotocol/docs/DEPLOYMENT.md
+++ b/modelcontextprotocol/docs/DEPLOYMENT.md
@@ -4,22 +4,13 @@ This guide covers transport modes and basic deployment options for the Atlan MCP
 
 ## Transport Modes
 
-The Atlan MCP Server supports three transport modes:
+The Atlan MCP Server supports three transport modes. For more details about MCP transport modes, see the [official MCP documentation](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
 
-### stdio (Default)
-- **Use case**: Local development, IDE integrations
-- **Benefits**: Simple, direct communication
-- **When to use**: Claude Desktop, Cursor IDE
-
-### SSE (Server-Sent Events)
-- **Use case**: Remote deployments, web browsers
-- **Benefits**: Real-time streaming, web-compatible
-- **When to use**: Cloud deployments, web clients
-
-### streamable-http
-- **Use case**: HTTP-based remote connections
-- **Benefits**: Standard HTTP, load balancer friendly
-- **When to use**: Kubernetes, containerized deployments
+| Transport Mode | Use Case | Benefits | When to Use |
+|---|---|---|---|
+| **stdio** (Default) | Local development, IDE integrations | Simple, direct communication | Claude Desktop, Cursor IDE |
+| **SSE** (Server-Sent Events) | Remote deployments, web browsers | Real-time streaming, web-compatible | Cloud deployments, web clients |
+| **streamable-http** | HTTP-based remote connections | Standard HTTP, load balancer friendly | Kubernetes, containerized deployments |
 
 ## Basic Deployment Examples
 


### PR DESCRIPTION
## Add Transport Mode Documentation

### Summary
Added documentation for the three MCP transport modes (stdio, SSE, streamable-http) to help users choose the right deployment option.

### Changes
- **README.md**: Added Transport Modes section with quick overview
- **docs/DEPLOYMENT.md**: New deployment guide with:
  - Transport mode descriptions and use cases
  - Basic deployment examples for each mode
  - Environment variable reference

### Transport Modes Added
- `stdio` (default): Local development, IDE integrations
- `sse`: Remote deployments, web clients  
- `streamable-http`: Kubernetes, containerized deployments

### Benefits
- Clear guidance on when to use each transport mode
- Simple deployment examples for quick setup
- Centralized deployment documentation

No breaking changes - all existing functionality preserved.