### PR TITLE
updated tool naming as per suggestion

### DIFF
--- a/modelcontextprotocol/.cursor/rules/project-structure.mdc
+++ b/modelcontextprotocol/.cursor/rules/project-structure.mdc
@@ -32,14 +32,17 @@ The main entry point for the MCP server. Registers and exposes tools defined in 
 ```python
 from mcp.server.fastmcp import FastMCP
 from tools import (
-    search_assets,
-    get_assets_by_dsl,
-    traverse_lineage,
-    update_assets,
+    create_glossary_category_assets,
+    create_glossary_assets,
+    create_glossary_term_assets,
     UpdatableAttribute,
     CertificateStatus,
     UpdatableAsset,
 )
+from tools.search import search_assets as search_assets_impl
+from tools.dsl import get_assets_by_dsl as get_assets_by_dsl_impl
+from tools.lineage import traverse_lineage as traverse_lineage_impl
+from tools.assets import update_assets as update_assets_impl
 from pyatlan.model.fields.atlan_fields import AtlanField
 from typing import Optional, Dict, Any, List, Union, Type
 from pyatlan.model.assets import Asset
@@ -51,35 +54,35 @@ mcp = FastMCP("Atlan MCP", dependencies=["pyatlan"])
 # Refer to the actual server.py and tools implementations for details.
 
 @mcp.tool()
-def search_assets_tool(
+def search_assets(
     conditions: Optional[Union[Dict[str, Any], str]] = None,
     # ... many other parameters ...
 ):
     """Advanced asset search using FluentSearch with flexible conditions."""
-    return search_assets(conditions=conditions, ...)
+    return search_assets_impl(conditions=conditions, ...)
 
 @mcp.tool()
-def get_assets_by_dsl_tool(dsl_query: Union[str, Dict[str, Any]]):
+def get_assets_by_dsl(dsl_query: Union[str, Dict[str, Any]]):
     """Execute the search with the given DSL query."""
-    return get_assets_by_dsl(dsl_query)
+    return get_assets_by_dsl_impl(dsl_query)
 
 @mcp.tool()
-def traverse_lineage_tool(
+def traverse_lineage(
     guid: str,
     direction: str, # UPSTREAM or DOWNSTREAM
     # ... other parameters ...
 ):
     """Traverse asset lineage in specified direction."""
-    return traverse_lineage(guid=guid, direction=direction, ...)
+    return traverse_lineage_impl(guid=guid, direction=direction, ...)
 
 @mcp.tool()
-def update_assets_tool(
+def update_assets(
     assets: Union[UpdatableAsset, List[UpdatableAsset]],
     attribute_name: UpdatableAttribute,
     attribute_values: List[Union[CertificateStatus, str]],
 ):
     """Update one or multiple assets with different values for the same attribute."""
-    return update_assets(assets=assets, attribute_name=attribute_name, attribute_values=attribute_values)
+    return update_assets_impl(assets=assets, attribute_name=attribute_name, attribute_values=attribute_values)
 ```
 
 ### settings.py

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -173,7 +173,7 @@ You can restrict access to specific tools using the `RESTRICTED_TOOLS` environme
         "-e",
         "ATLAN_AGENT_ID=<YOUR_AGENT_ID>",
         "-e",
-        "RESTRICTED_TOOLS=get_assets_by_dsl_tool,update_assets_tool",
+        "RESTRICTED_TOOLS=get_assets_by_dsl,update_assets",
         "ghcr.io/atlanhq/atlan-mcp-server:latest"
       ]
     }
@@ -193,7 +193,7 @@ You can restrict access to specific tools using the `RESTRICTED_TOOLS` environme
         "ATLAN_API_KEY": "<YOUR_API_KEY>",
         "ATLAN_BASE_URL": "https://<YOUR_INSTANCE>.atlan.com",
         "ATLAN_AGENT_ID": "<YOUR_AGENT_ID>",
-        "RESTRICTED_TOOLS": "get_assets_by_dsl_tool,update_assets_tool"
+        "RESTRICTED_TOOLS": "get_assets_by_dsl,update_assets"
       }
     }
   }
@@ -204,10 +204,10 @@ You can restrict access to specific tools using the `RESTRICTED_TOOLS` environme
 
 You can restrict any of the following tools:
 
-- `search_assets_tool` - Asset search functionality
-- `get_assets_by_dsl_tool` - DSL query execution
-- `traverse_lineage_tool` - Lineage traversal
-- `update_assets_tool` - Asset updates (descriptions, certificates)
+- `search_assets` - Asset search functionality
+- `get_assets_by_dsl` - DSL query execution
+- `traverse_lineage` - Lineage traversal
+- `update_assets` - Asset updates (descriptions, certificates)
 - `create_glossaries` - Glossary creation
 - `create_glossary_categories` - Category creation
 - `create_glossary_terms` - Term creation
@@ -217,19 +217,19 @@ You can restrict any of the following tools:
 #### Read-Only Access
 Restrict all write operations:
 ```
-RESTRICTED_TOOLS=update_assets_tool,create_glossaries,create_glossary_categories,create_glossary_terms
+RESTRICTED_TOOLS=update_assets,create_glossaries,create_glossary_categories,create_glossary_terms
 ```
 
 #### Disable DSL Queries
 For security or performance reasons:
 ```
-RESTRICTED_TOOLS=get_assets_by_dsl_tool
+RESTRICTED_TOOLS=get_assets_by_dsl
 ```
 
 #### Minimal Access
 Allow only basic search:
 ```
-RESTRICTED_TOOLS=get_assets_by_dsl_tool,update_assets_tool,traverse_lineage_tool,create_glossaries,create_glossary_categories,create_glossary_terms
+RESTRICTED_TOOLS=get_assets_by_dsl,update_assets,traverse_lineage,create_glossaries,create_glossary_categories,create_glossary_terms
 ```
 
 ### How It Works

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -4,10 +4,6 @@ import os
 from typing import Any, Dict, List
 from fastmcp import FastMCP
 from tools import (
-    search_assets,
-    get_assets_by_dsl,
-    traverse_lineage,
-    update_assets,
     create_glossary_category_assets,
     create_glossary_assets,
     create_glossary_term_assets,
@@ -15,6 +11,10 @@ from tools import (
     CertificateStatus,
     UpdatableAsset,
 )
+from tools.search import search_assets as search_assets_impl
+from tools.dsl import get_assets_by_dsl as get_assets_by_dsl_impl
+from tools.lineage import traverse_lineage as traverse_lineage_impl
+from tools.assets import update_assets as update_assets_impl
 from pyatlan.model.lineage import LineageDirection
 from utils.parameters import (
     parse_json_parameter,
@@ -40,7 +40,7 @@ mcp.add_middleware(tool_restriction)
 
 
 @mcp.tool()
-def search_assets_tool(
+def search_assets(
     conditions=None,
     negative_conditions=None,
     some_conditions=None,
@@ -242,7 +242,7 @@ def search_assets_tool(
         domain_guids = parse_list_parameter(domain_guids)
         guids = parse_list_parameter(guids)
 
-        return search_assets(
+        return search_assets_impl(
             conditions,
             negative_conditions,
             some_conditions,
@@ -266,7 +266,7 @@ def search_assets_tool(
 
 
 @mcp.tool()
-def get_assets_by_dsl_tool(dsl_query):
+def get_assets_by_dsl(dsl_query):
     """
     Execute the search with the given query
     dsl_query : Union[str, Dict[str, Any]] (required):
@@ -334,11 +334,11 @@ def get_assets_by_dsl_tool(dsl_query):
     }'''
     response = get_assets_by_dsl(dsl_query)
     """
-    return get_assets_by_dsl(dsl_query)
+    return get_assets_by_dsl_impl(dsl_query)
 
 
 @mcp.tool()
-def traverse_lineage_tool(
+def traverse_lineage(
     guid,
     direction,
     depth=1000000,
@@ -374,7 +374,7 @@ def traverse_lineage_tool(
 
     Examples:
         # Get lineage with default attributes
-        lineage = traverse_lineage_tool(
+        lineage = traverse_lineage(
             guid="asset-guid-here",
             direction="DOWNSTREAM",
             depth=1000,
@@ -391,7 +391,7 @@ def traverse_lineage_tool(
     # Parse include_attributes parameter if provided
     parsed_include_attributes = parse_list_parameter(include_attributes)
 
-    return traverse_lineage(
+    return traverse_lineage_impl(
         guid=guid,
         direction=direction_enum,
         depth=int(depth),
@@ -402,7 +402,7 @@ def traverse_lineage_tool(
 
 
 @mcp.tool()
-def update_assets_tool(
+def update_assets(
     assets,
     attribute_name,
     attribute_values,
@@ -426,7 +426,7 @@ def update_assets_tool(
 
     Examples:
         # Update certificate status for a single asset
-        result = update_assets_tool(
+        result = update_assets(
             assets={
                 "guid": "asset-guid-here",
                 "name": "Asset Name",
@@ -438,7 +438,7 @@ def update_assets_tool(
         )
 
         # Update user description for multiple assets
-        result = update_assets_tool(
+        result = update_assets(
             assets=[
                 {
                     "guid": "asset-guid-1",
@@ -460,7 +460,7 @@ def update_assets_tool(
         )
 
         # Update readme for a single asset with Markdown
-        result = update_assets_tool(
+        result = update_assets(
             assets={
                 "guid": "asset-guid-here",
                 "name": "Asset Name",
@@ -496,7 +496,7 @@ def update_assets_tool(
         else:
             updatable_assets = [UpdatableAsset(**asset) for asset in parsed_assets]
 
-        return update_assets(
+        return update_assets_impl(
             updatable_assets=updatable_assets,
             attribute_name=attr_enum,
             attribute_values=parsed_attribute_values,


### PR DESCRIPTION
## 🔧 Rename MCP Tools to Follow Clean Naming Convention
Resolved #75 

### Summary
Renamed MCP tool functions from `*_tool` suffix to clean `<action>_<type>` format to improve API consistency and remove redundant naming.

### Changes Made

**Tool Renames:**
- `search_assets_tool` → `search_assets`
- `get_assets_by_dsl_tool` → `get_assets_by_dsl` 
- `traverse_lineage_tool` → `traverse_lineage`
- `update_assets_tool` → `update_assets`

**Implementation Improvements:**
- Added clean top-level imports with `_impl` suffix to avoid naming conflicts
- Removed messy local imports before return statements
- Updated all docstring examples to use new tool names

**Documentation Updates:**
- Updated `README.md` tool restriction examples and available tools list
- Updated `.cursor/rules/project-structure.mdc` architecture documentation
- Fixed all configuration examples to use new tool names

### Testing
✅ All 7 tools properly registered and functional  
✅ No old tool names remaining  
✅ Server imports and starts successfully  
✅ No linting errors

### Breaking Change
⚠️ **Client code using old tool names will need to update to new names**

**Migration:**
```diff
- search_assets_tool(...)
+ search_assets(...)
```
```