### PR TITLE
perf: implement client singleton for connection pool reuse

### DIFF
--- a/modelcontextprotocol/client.py
+++ b/modelcontextprotocol/client.py
@@ -14,26 +14,25 @@ _client_instance: Optional[AtlanClient] = None
 def get_atlan_client() -> AtlanClient:
     """
     Get the singleton AtlanClient instance for connection reuse.
-    
+
     Returns:
         AtlanClient: The singleton AtlanClient instance.
-        
+
     Raises:
         Exception: If client creation fails.
     """
     global _client_instance
-    
+
     if _client_instance is None:
         settings = Settings()
         try:
             _client_instance = AtlanClient(
-                base_url=settings.ATLAN_BASE_URL,
-                api_key=settings.ATLAN_API_KEY
+                base_url=settings.ATLAN_BASE_URL, api_key=settings.ATLAN_API_KEY
             )
             _client_instance.update_headers(settings.headers)
             logger.info("AtlanClient initialized successfully")
         except Exception:
             logger.error("Failed to create Atlan client", exc_info=True)
             raise
-    
+
     return _client_instance


### PR DESCRIPTION
## Problem
The current implementation creates a new `AtlanClient` instance on every `get_atlan_client()` call. Each AtlanClient creates a new `httpx.Client` with its own connection pool, retry logic, and configuration. This is wasteful and hurts performance.

## Solution  
Implement a simple singleton pattern to reuse the same AtlanClient instance across all operations.

## Impact
- ✅ **Connection reuse**: HTTP connections are properly pooled and reused
- ✅ **Performance**: Eliminates overhead of creating new clients repeatedly  
- ✅ **Memory efficiency**: Single client instance instead of many
- ✅ **No API changes**: Drop-in replacement
