### PR TITLE
Updated local build instructions for E2E testing with Claude

### DIFF
--- a/modelcontextprotocol/docs/LOCAL_BUILD.md
+++ b/modelcontextprotocol/docs/LOCAL_BUILD.md
@@ -45,3 +45,25 @@ uv run .venv/bin/atlan-mcp-server
 ```bash
 uv run mcp dev server.py
 ```
+7. Integrate local MCP changes with Claude Desktop(For E2E testing):
+```bash
+When claude is integrated with Atlan MCP, it runs its own MCP server 
+Update config in claude desktop config as below to use your local code changes for testing end to end:
+{
+  "mcpServers": {
+    "atlan-local": {
+      "command": "uv",
+      "args": [
+        "run", 
+        "/path/to/agent-toolkit/modelcontextprotocol/.venv/bin/atlan-mcp-server"
+      ],
+      "cwd": "/path/to/agent-toolkit/modelcontextprotocol",
+      "env": {
+        "ATLAN_API_KEY": "your_api_key",
+        "ATLAN_BASE_URL": "https://your-instance.atlan.com",
+        "ATLAN_AGENT_ID": "your_agent_id"
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
This PR enhances the local build instructions to add E2E testing with Claude integrated. 