### PR TITLE
Add get_asset_history tool 

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -733,16 +733,17 @@ def get_asset_history_tool(
             Either guid or qualified_name must be provided.
         type_name (str, optional): Type name of the asset (required when using qualified_name).
             Examples: "Table", "Column", "DbtModel", "AtlasGlossary"
-        size (int): Number of history entries to return. Defaults to 10.
+        size (int): Number of history entries to return. Defaults to 10. Maximum is 50.
+            Size validation is handled automatically by Pydantic.
         sort_order (str): Sort order for results. "ASC" for oldest first, "DESC" for newest first.
-            Defaults to "DESC".
+            Defaults to "DESC". Validation is handled automatically by Pydantic.
 
     Returns:
-        Dict[str, Any]: Dictionary containing:
-            - entityAudits: List of audit entries with details about each change
+        AssetHistoryResponse: Pydantic model containing:
+            - entity_audits: List of audit entries with details about each change
             - count: Number of audit entries returned
-            - totalCount: Total number of audit entries available
-            - errors: List of any errors encountered
+            - total_count: Total number of audit entries available
+            - errors: List of any validation or retrieval errors encountered
 
     Examples:
         # Get history by GUID

--- a/modelcontextprotocol/tools/__init__.py
+++ b/modelcontextprotocol/tools/__init__.py
@@ -16,6 +16,9 @@ from .models import (
     Glossary,
     GlossaryCategory,
     GlossaryTerm,
+    AssetHistoryRequest,
+    AssetHistoryResponse,
+    AuditEntry,
 )
 
 __all__ = [
@@ -35,4 +38,7 @@ __all__ = [
     "Glossary",
     "GlossaryCategory",
     "GlossaryTerm",
+    "AssetHistoryRequest",
+    "AssetHistoryResponse",
+    "AuditEntry",
 ]


### PR DESCRIPTION
This PR adds a new tool get_asset_history for the following usecases

Tested for prompts like:
"when was the description updated and who updated it for x asset?"
"who was the owner of this x asset on y date"
"what was the description of this asset before it was last updated?"
"who changes the description from x to y for z asset?"


<img width="533" height="841" alt="Screenshot 2025-09-18 at 11 20 51 PM" src="https://github.com/user-attachments/assets/1c04f2d4-1beb-488f-8bee-15e990d6482f" />
<img width="546" height="532" alt="Screenshot 2025-09-18 at 11 22 36 PM" src="https://github.com/user-attachments/assets/143926d2-dc49-4f76-a2c2-61d791554eaa" />
<img width="520" height="854" alt="Screenshot 2025-09-18 at 11 24 25 PM" src="https://github.com/user-attachments/assets/dabc13db-b689-4267-ae75-9501a36d5ab0" />
<img width="544" height="751" alt="Screenshot 2025-09-18 at 11 26 28 PM" src="https://github.com/user-attachments/assets/a0e3e14c-9e87-4d81-886d-178ab8a60d61" />

<img width="285" height="796" alt="Screenshot 2025-09-18 at 11 26 53 PM" src="https://github.com/user-attachments/assets/e7a870db-762a-4918-929f-a6255938c8ca" />


