### PR TITLE
Fix transport configuration not working with PyPI entry point 

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -23,6 +23,7 @@ from utils.parameters import (
     parse_list_parameter,
 )
 from middleware import ToolRestrictionMiddleware
+from settings import get_settings
 
 
 mcp = FastMCP("Atlan MCP Server", dependencies=["pyatlan", "fastmcp"])
@@ -904,26 +905,35 @@ def create_glossary_categories(categories) -> List[Dict[str, Any]]:
 
 
 def main():
-    mcp.run()
+    """Main entry point for the Atlan MCP Server."""
 
-
-if __name__ == "__main__":
+    settings = get_settings()
+    
     parser = argparse.ArgumentParser(description="Atlan MCP Server")
     parser.add_argument(
         "--transport",
         type=str,
-        default="stdio",
+        default=settings.MCP_TRANSPORT,
         choices=["stdio", "sse", "streamable-http"],
         help="Transport protocol (stdio/sse/streamable-http)",
     )
     parser.add_argument(
-        "--host", type=str, default="0.0.0.0", help="Host to run the server on"
+        "--host",
+        type=str,
+        default=settings.MCP_HOST,
+        help="Host to run the server on",
     )
     parser.add_argument(
-        "--port", type=int, default=8000, help="Port to run the server on"
+        "--port",
+        type=int,
+        default=settings.MCP_PORT,
+        help="Port to run the server on",
     )
     parser.add_argument(
-        "--path", type=str, default="/", help="Path of the streamable HTTP server"
+        "--path",
+        type=str,
+        default=settings.MCP_PATH,
+        help="Path of the streamable HTTP server",
     )
     args = parser.parse_args()
 
@@ -937,3 +947,7 @@ if __name__ == "__main__":
         }
     # Run the server with the specified transport and host/port/path
     mcp.run(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -908,7 +908,7 @@ def main():
     """Main entry point for the Atlan MCP Server."""
 
     settings = get_settings()
-    
+
     parser = argparse.ArgumentParser(description="Atlan MCP Server")
     parser.add_argument(
         "--transport",

--- a/modelcontextprotocol/settings.py
+++ b/modelcontextprotocol/settings.py
@@ -13,6 +13,10 @@ class Settings(BaseSettings):
     ATLAN_AGENT_ID: str = "NA"
     ATLAN_AGENT: str = "atlan-mcp"
     ATLAN_MCP_USER_AGENT: str = f"Atlan MCP Server {MCP_VERSION}"
+    MCP_TRANSPORT: str = "stdio"
+    MCP_HOST: str = "0.0.0.0"
+    MCP_PORT: int = 8000
+    MCP_PATH: str = "/"
 
     @property
     def headers(self) -> dict:


### PR DESCRIPTION
### **Bug Description**
When the `atlan-mcp-server` package was installed via PyPI and executed using `uvx atlan-mcp-server`, the transport configuration was not being applied. The server would always start in `stdio` mode, ignoring both environment variables (`MCP_TRANSPORT`, `MCP_HOST`, etc.) and command-line arguments.

### **Root Cause** 
The argument parsing logic was only executed in the `if __name__ == "__main__":` block, which runs when the script is executed directly (`python server.py`) but not when called via the PyPI entry point (`uvx atlan-mcp-server`). The PyPI entry point calls the `main()` function directly, bypassing the argument parsing.

### **Solution**
Moved the argument parsing logic from the `if __name__ == "__main__":` block into the `main()` function itself. This ensures that:

- Environment variables are properly read (`MCP_TRANSPORT`, `MCP_HOST`, `MCP_PORT`, `MCP_PATH`)
- Command-line arguments work as expected
- Transport configuration works regardless of execution method (direct Python execution or PyPI entry point)