### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] - 2025-09-22
+
+### Fixed
+- Transport configuration not working when installed via PyPI and executed using `uvx atlan-mcp-server` - server would ignore environment variables and command-line arguments, always defaulting to stdio mode
+
 ## [0.2.8] - 2025-09-15
 
 ### Added

--- a/modelcontextprotocol/version.py
+++ b/modelcontextprotocol/version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"


### PR DESCRIPTION
This pull request updates the package to version 0.2.9 and addresses a key bug affecting transport configuration when running the server via PyPI. The main change ensures that environment variables and command-line arguments are properly respected, rather than always defaulting to stdio mode.

Version update:

* Bumped the version in `modelcontextprotocol/version.py` from `0.2.8` to `0.2.9`.

Bug fix:

* Fixed an issue where transport configuration was ignored when running `uvx atlan-mcp-server` after installing via PyPI; the server now correctly uses environment variables and command-line arguments instead of always defaulting to stdio mode.