### PR TITLE
fix(mcp): tag MCP SQL queries with /* atlan-mcp */ comment for log observability

### DIFF
--- a/modelcontextprotocol/tools/query.py
+++ b/modelcontextprotocol/tools/query.py
@@ -80,9 +80,14 @@ def query_asset(
         client = get_atlan_client()
 
         # Build query request
+        # Prepend an MCP origin comment so queries are identifiable in
+        # downstream observability logs (e.g. Heka's db.statement OTEL field).
+        # QueryRequest has no application/source field, so a SQL comment is
+        # the only portable way to tag origin without SDK changes.
         logger.debug("Building QueryRequest object")
+        tagged_sql = f"/* atlan-mcp */ {sql.strip()}"
         query_request = QueryRequest(
-            sql=sql,
+            sql=tagged_sql,
             data_source_name=connection_qualified_name,
             default_schema=default_schema,
         )


### PR DESCRIPTION
## Summary

- **Root cause context:** MCP-originated SQL queries executed via `query_assets_tool` are currently indistinguishable from UI-initiated queries in Heka's `SQL_QUERY_EXECUTED` OTEL logs because `pyatlan.model.query.QueryRequest` has no `application` or `source` field, and Heka defaults all queries to `application=adhoc`.
- **Fix:** Prepend `/* atlan-mcp */` as a SQL block comment to every query submitted through `query_asset()`. This comment passes through Heka unchanged and appears in the `db.statement` field of the OTEL log, enabling reliable log filtering.
- **Why comment, not field:** `QueryRequest` exposes only `sql`, `data_source_name`, and `default_schema`. `AtlanObject` uses `Extra.ignore`, so passing `application=` silently no-ops. A SQL comment is the only zero-dependency way to tag origin without pyatlan SDK changes.

## Change

`modelcontextprotocol/tools/query.py`
```python
# Before
query_request = QueryRequest(
    sql=sql,
    data_source_name=connection_qualified_name,
    default_schema=default_schema,
)

# After
tagged_sql = f"/* atlan-mcp */ {sql.strip()}"
query_request = QueryRequest(
    sql=tagged_sql,
    data_source_name=connection_qualified_name,
    default_schema=default_schema,
)
```

## Log impact

After this fix, MCP queries are directly filterable in ClickHouse:
```sql
SELECT Body FROM otel_logs.service_logs
WHERE ServiceName = 'heka'
  AND Body LIKE '%/* atlan-mcp */%'
  AND Body LIKE '%jdbcExtras%'
```

## Related

This is the **observability companion** to a separate Heka-side fix where `credentialStrategy=custombyocsso` unconditionally uses the service account private key for Snowflake JDBC connections, ignoring the validated `byocSsoAccessToken`. The Heka fix is required to actually resolve the RBAC bypass; this PR ensures MCP queries are auditable in the interim.

## Test plan

- [ ] Run `query_assets_tool` against a Snowflake connection on a test tenant
- [ ] Confirm `/* atlan-mcp */` appears in `db.statement` field in Heka OTEL logs (`otel_logs.service_logs` where `ServiceName='heka'`)
- [ ] Confirm query executes successfully with comment prefix (Snowflake, BigQuery, Redshift all support `/* */` block comments)
- [ ] Verify no regression in existing tool tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)