### PR TITLE
feat(mcp): add create_context_repos and create_skills tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The Atlan MCP server uses OAuth 2.1 authentication. Users authenticate via the `
 
 ## Available MCP Tools
 
-12 tools are enabled by default for most customers. 3 additional tools are available but require enablement per tenant via feature flags.
+14 tools are enabled by default for most customers. 3 additional tools are available but require enablement per tenant via feature flags.
 
 ### Search & Discovery
 - **`semantic_search_tool`** - Natural language search across all data assets using AI-powered semantic understanding.
@@ -32,6 +32,11 @@ The Atlan MCP server uses OAuth 2.1 authentication. Users authenticate via the `
 ### Data Mesh
 - **`create_domains`** - Create data domains and subdomains.
 - **`create_data_products`** - Create data products linked to domains and assets.
+
+### Agentic Context
+- **`create_context_repos`** - Create a ContextRepository bundle (repo + paired output Skill + bundled files) in one call. Each file in `artifacts` becomes a SkillArtifact under the linked Skill AND is uploaded to object storage, so it renders in the Atlan UI file tree. Supports `input_assets` (Tables / Glossary terms linked as input context) and an `activate` flag that flips lifecycle to ACTIVE + VERIFIED.
+- **`create_skills`** - Create standalone Skill assets. Use this only for SYSTEM/CUSTOM skills that exist independently of a context repo; otherwise let `create_context_repos` create the linked skill.
+- To discover existing assets, use `semantic_search_tool` or `search_assets_tool` with `asset_type="ContextRepository"`, `"Skill"`, or `"SkillArtifact"`.
 
 ### Data Quality
 - **`create_dq_rules_tool`** - Create data quality rules (null checks, uniqueness, regex, custom SQL, etc.).

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -151,6 +151,8 @@ Open `Cursor > Settings > Tools & Integrations > New MCP Server` to include the 
 | `schedule_dq_rules` | Schedule data quality rule execution for assets using cron expressions |
 | `delete_dq_rules`   | Delete one or multiple data quality rules by GUID                 |
 | `query_asset`       | Execute SQL queries on table/view assets                          |
+| `create_context_repos` | Create a ContextRepository bundle (repo + paired Skill + SkillArtifacts uploaded to object storage) so the bundle renders in the Atlan UI |
+| `create_skills`     | Create standalone Skill assets (for SYSTEM/CUSTOM skills independent of any repo) |
 
 ## Tool Access Control
 
@@ -220,6 +222,8 @@ You can restrict any of the following tools:
 - `update_dq_rules_tool` - Data quality rule updates
 - `schedule_dq_rules_tool` - Data quality rule scheduling
 - `delete_dq_rules_tool` - Data quality rule deletion
+- `create_context_repos` - ContextRepository bundle creation
+- `create_skills` - Standalone Skill creation
 
 ### Common Use Cases
 

--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.14.0",
-    "pyatlan>=6.0.1",
+    "pyatlan>=9.4.1",
     "uvicorn>=0.35.0"
 ]
 

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -14,6 +14,8 @@ from tools import (
     create_glossary_term_assets,
     create_data_domain_assets,
     create_data_product_assets,
+    create_context_repository_assets,
+    create_skill_assets,
     create_dq_rules,
     schedule_dq_rules,
     delete_dq_rules,
@@ -1043,6 +1045,138 @@ def create_data_products(products) -> List[Dict[str, Any]]:
         return {"error": f"Invalid JSON format for products parameter: {str(e)}"}
 
     return create_data_product_assets(products)
+
+
+@mcp.tool()
+def create_context_repos(repos) -> List[Dict[str, Any]]:
+    """
+    Create one or multiple ContextRepository BUNDLES (repo + linked Skill +
+    bundled files) in Atlan. Implements the canonical agent-bundle flow:
+
+        ContextRepository (DRAFT)
+          ├─ contextRepositoryAgentInstructions: <markdown>
+          ├─ contextInputAssets[]: Tables + Glossary terms (links)
+          └─ contextOutputSkill (1:1) → ONE Skill (skillType=CONTEXT_REPO)
+                └─ skillArtifacts[]: one per file in `artifacts`
+
+    Each file (`artifacts[i]`) is persisted as a SkillArtifact entity AND
+    uploaded as bytes to object storage via a presigned URL. The UI reads
+    `filePath: s3://atlan-bucket/context-repos/<repo_guid>/<displayName>` to
+    build the file tree; both bytes and inline `description` are populated so
+    the UI preview renders even if the storage layer is slow.
+
+    To discover existing repositories use semantic_search_tool or
+    search_assets_tool with asset_type="ContextRepository".
+
+    Args:
+        repos (Union[Dict[str, Any], List[Dict[str, Any]]]): A single
+            ContextRepositorySpec or a list. Each spec:
+            - name (str, required): Repo/Skill name (shared by convention).
+            - user_description (str, optional): Repo description.
+            - agent_instructions (str, optional): Markdown body stored on
+              contextRepositoryAgentInstructions (LLM guidance).
+            - target_connection_qualified_name (str, optional): Connection
+              qualified name used as the query execution engine
+              (e.g. "default/snowflake/1657275059").
+            - input_assets (List[Dict], optional): Assets linked via
+              contextInputAssets. Each item: {"guid", "type_name"} where
+              type_name is e.g. "Table", "AtlasGlossaryTerm", "DataProduct".
+            - artifacts (List[Dict], optional): Files in the bundle. Each:
+                - display_name (str, required): full relative path with
+                  extension, e.g. "soul.md", "skills/refunds/SKILL.md",
+                  "semantic_models/orders.yaml". The UI's file-tree folders
+                  come from the slashes in this path.
+                - content (str, required): the actual file body. Uploaded to
+                  object storage AND stored on description for inline preview.
+            - activate (bool, optional, default False): if True, flip the
+              ContextRepository to ACTIVE and certificateStatus to VERIFIED
+              on both repo and Skill at the end.
+
+    Returns:
+        List[Dict[str, Any]]: a flat list of dicts describing every created
+            or updated asset:
+            - operation: "CREATE" or "UPDATE"
+            - guid: <asset-guid>
+            - name: <asset-name>
+            - qualified_name: <asset-qualified-name>
+            - type_name: "ContextRepository" | "Skill" | "SkillArtifact"
+
+    Example:
+        create_context_repos({
+            "name": "Refunds Agent",
+            "user_description": "Tier-1 refunds + escalations bundle.",
+            "agent_instructions": "Default currency USD; always cite policy.",
+            "target_connection_qualified_name": "default/snowflake/1657275059",
+            "input_assets": [
+                {"guid": "abc-...", "type_name": "Table"},
+                {"guid": "def-...", "type_name": "AtlasGlossaryTerm"}
+            ],
+            "artifacts": [
+                {"display_name": "soul.md", "content": "# Voice & Tone\n..."},
+                {"display_name": "skills/skill_index.md",
+                 "content": "- refunds: process customer refunds..."},
+                {"display_name": "skills/refunds/SKILL.md",
+                 "content": "# Refunds\n## When to use..."},
+                {"display_name": "semantic_models/orders.yaml",
+                 "content": "version: 1\nmetrics: ...\n"}
+            ],
+            "activate": False
+        })
+    """
+    try:
+        repos = parse_json_parameter(repos)
+    except json.JSONDecodeError as e:
+        return {"error": f"Invalid JSON format for repos parameter: {str(e)}"}
+
+    return create_context_repository_assets(repos)
+
+
+@mcp.tool()
+def create_skills(skills) -> List[Dict[str, Any]]:
+    """
+    Create one or multiple standalone Skill assets in Atlan.
+
+    Skills bundle instructions and artifacts consumed by an AI agent at runtime.
+    A Skill can be standalone (SYSTEM / CUSTOM) or the output of a
+    ContextRepository (CONTEXT_REPO). To discover existing skills use
+    semantic_search_tool or search_assets_tool with asset_type="Skill" (or
+    asset_type="SkillArtifact" for the contained files).
+
+    For Skills that belong to a ContextRepository bundle (the common case), use
+    `create_context_repos` instead — it creates the repo + paired Skill + the
+    bundled SkillArtifacts (with object-storage upload) atomically. This tool
+    is only for SYSTEM/CUSTOM skills that exist independently of any repo.
+
+    IMPORTANT BUSINESS RULES & CONSTRAINTS:
+    - Use clear, capability-oriented names ("Refund Policy", "Fabric Care").
+    - skill_version is a free-form version label (e.g., "1.0.0").
+
+    Args:
+        skills (Union[Dict[str, Any], List[Dict[str, Any]]]): A single skill
+            specification or a list. Each specification can contain:
+            - name (str): Name of the skill (required)
+            - user_description (str, optional): Detailed description
+            - certificate_status (str, optional): "VERIFIED", "DRAFT", or "DEPRECATED"
+            - skill_version (str, optional): Free-form version label
+
+    Returns:
+        List[Dict[str, Any]]: List of dictionaries with details for each
+            created Skill: guid, name, qualified_name, operation.
+
+    Example:
+        create_skills({
+            "name": "Voice and Tone",
+            "user_description": "Org-wide voice-and-tone policy applied to every agent.",
+            "skill_version": "1.0.0",
+            "certificate_status": "VERIFIED"
+        })
+    """
+    try:
+        skills = parse_json_parameter(skills)
+    except json.JSONDecodeError as e:
+        return {"error": f"Invalid JSON format for skills parameter: {str(e)}"}
+
+    return create_skill_assets(skills)
 
 
 @mcp.tool()

--- a/modelcontextprotocol/tools/__init__.py
+++ b/modelcontextprotocol/tools/__init__.py
@@ -15,6 +15,10 @@ from .glossary import (
     create_glossary_term_assets,
 )
 from .domain import create_data_domain_assets, create_data_product_assets
+from .context_repo import (
+    create_context_repository_assets,
+    create_skill_assets,
+)
 from .models import (
     CertificateStatus,
     UpdatableAttribute,
@@ -31,6 +35,10 @@ from .models import (
     ScheduledAssetInfo,
     DQRuleInfo,
     DQRuleDeleteResponse,
+    ContextBundleArtifactSpec,
+    ContextInputAssetRef,
+    ContextRepositorySpec,
+    SkillSpec,
 )
 
 __all__ = [
@@ -44,6 +52,8 @@ __all__ = [
     "create_glossary_term_assets",
     "create_data_domain_assets",
     "create_data_product_assets",
+    "create_context_repository_assets",
+    "create_skill_assets",
     "CertificateStatus",
     "UpdatableAttribute",
     "UpdatableAsset",
@@ -63,4 +73,8 @@ __all__ = [
     "ScheduledAssetInfo",
     "DQRuleInfo",
     "DQRuleDeleteResponse",
+    "ContextBundleArtifactSpec",
+    "ContextInputAssetRef",
+    "ContextRepositorySpec",
+    "SkillSpec",
 ]

--- a/modelcontextprotocol/tools/context_repo.py
+++ b/modelcontextprotocol/tools/context_repo.py
@@ -1,0 +1,402 @@
+"""ContextRepository + Skill + SkillArtifact bundle persistence.
+
+Mirrors the canonical agent-bundle flow at
+`skills/agent-bundle/scripts/publish_to_atlan.py`:
+
+    1. Paired create — ContextRepository AND its contextOutputSkill go to
+       /api/meta/entity/bulk in a single request with negative guids so the
+       server resolves the cross-reference atomically.
+    2. Per artifact — TWO writes:
+         a. Entity row to /api/meta/entity/bulk with the six required UI
+            fields (name, displayName, filePath, fileType, description,
+            skillArtifactRepoGuid) plus the skillSource relationship.
+         b. Body bytes to S3 via /api/service/files/presignedUrl + PUT.
+    3. Optional activate — flips contextRepositoryLifecycleStatus to ACTIVE
+       and certificateStatus to VERIFIED on both repo and skill.
+
+Idempotent: if an artifact with the same displayName already exists under
+the bundle's Skill, its qualifiedName is reused (so re-publishing overwrites
+the body in place instead of producing duplicates).
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union
+
+from pyatlan.client.constants import API, HTTPMethod
+from pyatlan.model.assets import Skill
+from pyatlan.utils import EndPoint
+
+from client import get_atlan_client
+from utils import save_assets
+from .models import (
+    ContextBundleArtifactSpec,
+    ContextRepositorySpec,
+    SkillSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+S3_PREFIX = "s3://atlan-bucket/context-repos"
+
+BULK_ENTITY = API("entity/bulk", HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.ATLAS)
+PRESIGNED_URL = API(
+    "files/presignedUrl", HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.HERACLES
+)
+INDEX_SEARCH = API(
+    "search/indexsearch", HTTPMethod.POST, HTTPStatus.OK, endpoint=EndPoint.ATLAS
+)
+
+CONTENT_TYPE_BY_EXT = {
+    "md": "text/markdown",
+    "yaml": "application/x-yaml",
+    "yml": "application/x-yaml",
+    "json": "application/json",
+    "sql": "text/plain",
+    "csv": "text/csv",
+    "py": "text/plain",
+    "txt": "text/plain",
+}
+
+ARTIFACT_KIND_BY_EXT = {"md", "yaml", "json", "sql", "csv", "py"}
+
+
+def _nano21() -> str:
+    alphabet = string.ascii_letters + string.digits + "-_"
+    return "".join(secrets.choice(alphabet) for _ in range(21))
+
+
+def _basename_no_ext(display_name: str) -> str:
+    base = display_name.rsplit("/", 1)[-1]
+    return base.rsplit(".", 1)[0] if "." in base else base
+
+
+def _ext_of(display_name: str) -> str:
+    base = display_name.rsplit("/", 1)[-1]
+    return base.rsplit(".", 1)[-1].lower() if "." in base else "txt"
+
+
+def _kind_of(ext: str) -> str:
+    return ext if ext in ARTIFACT_KIND_BY_EXT else "md"
+
+
+def _bulk_create(entities: List[Dict[str, Any]]) -> Dict[str, Any]:
+    client = get_atlan_client()
+    return client._call_api(BULK_ENTITY, request_obj={"entities": entities})
+
+
+def _index_search(payload: Dict[str, Any]) -> Dict[str, Any]:
+    client = get_atlan_client()
+    return client._call_api(INDEX_SEARCH, request_obj=payload)
+
+
+def _presigned_put_url(repo_guid: str, display_name: str) -> str:
+    client = get_atlan_client()
+    res = client._call_api(
+        PRESIGNED_URL,
+        request_obj={
+            "key": f"context-repos/{repo_guid}/{display_name}",
+            "expiry": "120s",
+            "method": "PUT",
+        },
+    )
+    url = (res or {}).get("url")
+    if not url:
+        raise RuntimeError(f"presignedUrl response missing 'url': {res!r}")
+    return url
+
+
+def _s3_put(url: str, body: bytes, content_type: str) -> int:
+    """PUT bytes to a presigned URL. Uses the same httpx session as the SDK
+    but explicitly drops Atlan auth headers — the URL is already signed."""
+    client = get_atlan_client()
+    sess = client._session
+    # Strip the SDK's Authorization header for the S3 put; the presigned URL
+    # carries its own credentials, and S3 rejects extra auth headers.
+    resp = sess.put(url, content=body, headers={"Content-Type": content_type})
+    return resp.status_code
+
+
+def _ensure_repo_and_skill(spec: ContextRepositorySpec) -> Dict[str, str]:
+    """Persist ContextRepository + paired Skill via a single bulk-create with
+    negative guids cross-referencing each other. Returns identifiers."""
+    repo_qn = f"default/context/{_nano21()}"
+    skill_qn = f"default/skill/{_nano21()}"
+
+    input_assets = [
+        {"guid": ref.guid, "typeName": ref.type_name}
+        for ref in (spec.input_assets or [])
+    ]
+
+    repo_attrs: Dict[str, Any] = {
+        "name": spec.name,
+        "qualifiedName": repo_qn,
+        "contextRepositoryLifecycleStatus": "DRAFT",
+        "contextRepositoryRepoType": "agent_bundle",
+    }
+    if spec.user_description:
+        repo_attrs["description"] = spec.user_description
+    if spec.agent_instructions is not None:
+        repo_attrs["contextRepositoryAgentInstructions"] = spec.agent_instructions
+    if spec.target_connection_qualified_name:
+        repo_attrs["contextRepositoryTargetConnectionQualifiedName"] = (
+            spec.target_connection_qualified_name
+        )
+
+    payload = [
+        {
+            "guid": "-1",
+            "typeName": "ContextRepository",
+            "attributes": repo_attrs,
+            "relationshipAttributes": {
+                "contextInputAssets": input_assets,
+                "contextOutputSkill": {"guid": "-2", "typeName": "Skill"},
+            },
+        },
+        {
+            "guid": "-2",
+            "typeName": "Skill",
+            "attributes": {
+                "name": spec.name,
+                "qualifiedName": skill_qn,
+                "skillType": "CONTEXT_REPO",
+                "skillVersion": "0.1.0",
+                "certificateStatus": "DRAFT",
+            },
+        },
+    ]
+    res = _bulk_create(payload)
+    created = (res or {}).get("mutatedEntities", {}).get("CREATE", []) or []
+    repo_guid: Optional[str] = next(
+        (e["guid"] for e in created if e.get("typeName") == "ContextRepository"),
+        None,
+    )
+    skill_guid: Optional[str] = next(
+        (e["guid"] for e in created if e.get("typeName") == "Skill"),
+        None,
+    )
+    if not repo_guid:
+        raise RuntimeError(
+            f"Could not extract ContextRepository guid from bulk-create response: {res!r}"
+        )
+    return {
+        "repo_qn": repo_qn,
+        "repo_guid": repo_guid,
+        "skill_qn": skill_qn,
+        "skill_guid": skill_guid or "",
+    }
+
+
+def _index_existing_artifacts(skill_qn: str) -> Dict[str, str]:
+    """Return {displayName: qualifiedName} for every SkillArtifact under skill_qn."""
+    res = _index_search(
+        {
+            "dsl": {
+                "from": 0,
+                "size": 200,
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"term": {"__typeName.keyword": "SkillArtifact"}},
+                            {"prefix": {"qualifiedName": f"{skill_qn}/artifact/"}},
+                        ]
+                    }
+                },
+            },
+            "attributes": ["displayName", "qualifiedName"],
+        }
+    )
+    out: Dict[str, str] = {}
+    for e in (res or {}).get("entities", []) or []:
+        a = e.get("attributes") or {}
+        dn, qn = a.get("displayName"), a.get("qualifiedName")
+        if dn and qn:
+            out[dn] = qn
+    return out
+
+
+def _publish_artifact(
+    repo_guid: str,
+    skill_qn: str,
+    art: ContextBundleArtifactSpec,
+    existing_qn: Optional[str],
+) -> Dict[str, Any]:
+    body_bytes = art.content.encode("utf-8")
+    ext = _ext_of(art.display_name)
+    kind = _kind_of(ext)
+    qn = existing_qn or f"{skill_qn}/artifact/{kind}/{_nano21()}"
+    op = "UPDATE" if existing_qn else "CREATE"
+
+    entity = {
+        "typeName": "SkillArtifact",
+        "attributes": {
+            "name": _basename_no_ext(art.display_name),
+            "qualifiedName": qn,
+            "displayName": art.display_name,
+            "filePath": f"{S3_PREFIX}/{repo_guid}/{art.display_name}",
+            "fileType": ext,
+            "description": art.content,
+            "skillArtifactContent": art.content,
+            "skillArtifactContentType": ext,
+            "skillArtifactRepoGuid": repo_guid,
+        },
+        "relationshipAttributes": {
+            "skillSource": {
+                "typeName": "Skill",
+                "uniqueAttributes": {"qualifiedName": skill_qn},
+            },
+        },
+    }
+    bulk_res = _bulk_create([entity])
+    # Locate the just-saved guid from the bulk response so we can return it.
+    art_guid: Optional[str] = None
+    for k in ("CREATE", "UPDATE", "PARTIAL_UPDATE"):
+        for e in (bulk_res or {}).get("mutatedEntities", {}).get(k, []) or []:
+            if e.get("typeName") == "SkillArtifact" and (
+                e.get("attributes", {}).get("qualifiedName") == qn
+            ):
+                art_guid = e.get("guid")
+                break
+        if art_guid:
+            break
+
+    # S3 upload — the presigned URL is signed for the exact key.
+    presigned = _presigned_put_url(repo_guid, art.display_name)
+    content_type = CONTENT_TYPE_BY_EXT.get(ext, "text/plain")
+    s3_status = _s3_put(presigned, body_bytes, content_type)
+    if not (200 <= s3_status < 300):
+        raise RuntimeError(
+            f"S3 PUT for {art.display_name!r} failed with status {s3_status}"
+        )
+
+    return {
+        "operation": op,
+        "name": art.display_name,
+        "guid": art_guid or "",
+        "qualified_name": qn,
+        "type_name": "SkillArtifact",
+    }
+
+
+def _activate_bundle(
+    spec_name: str, repo_qn: str, skill_qn: str, owner_user: Optional[str]
+) -> None:
+    entities = [
+        {
+            "typeName": "ContextRepository",
+            "attributes": {
+                "qualifiedName": repo_qn,
+                "name": spec_name,
+                "contextRepositoryLifecycleStatus": "ACTIVE",
+                "certificateStatus": "VERIFIED",
+                **({"ownerUsers": [owner_user]} if owner_user else {}),
+            },
+        },
+        {
+            "typeName": "Skill",
+            "attributes": {
+                "qualifiedName": skill_qn,
+                "name": spec_name,
+                "certificateStatus": "VERIFIED",
+                **({"ownerUsers": [owner_user]} if owner_user else {}),
+            },
+        },
+    ]
+    _bulk_create(entities)
+
+
+def create_context_repository_assets(
+    repos: Union[Dict[str, Any], List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Create one or multiple ContextRepository bundles (repo + skill + artifacts).
+
+    See ContextRepositorySpec for the input shape. Returns a flat list of
+    dicts describing each created/updated asset:
+
+        {
+          "operation": "CREATE" | "UPDATE",
+          "guid": "<asset-guid>",
+          "name": "<asset-name>",
+          "qualified_name": "<asset-qualified-name>",
+          "type_name": "ContextRepository" | "Skill" | "SkillArtifact",
+        }
+    """
+    data = repos if isinstance(repos, list) else [repos]
+    logger.info(f"Creating {len(data)} ContextRepository bundle(s)")
+    specs = [ContextRepositorySpec(**item) for item in data]
+
+    results: List[Dict[str, Any]] = []
+    for spec in specs:
+        ids = _ensure_repo_and_skill(spec)
+        repo_guid = ids["repo_guid"]
+        skill_qn = ids["skill_qn"]
+        results.extend(
+            [
+                {
+                    "operation": "CREATE",
+                    "guid": ids["repo_guid"],
+                    "name": spec.name,
+                    "qualified_name": ids["repo_qn"],
+                    "type_name": "ContextRepository",
+                },
+                {
+                    "operation": "CREATE",
+                    "guid": ids["skill_guid"],
+                    "name": spec.name,
+                    "qualified_name": skill_qn,
+                    "type_name": "Skill",
+                },
+            ]
+        )
+
+        artifacts = spec.artifacts or []
+        if artifacts:
+            existing = _index_existing_artifacts(skill_qn)
+            for art in artifacts:
+                results.append(
+                    _publish_artifact(
+                        repo_guid=repo_guid,
+                        skill_qn=skill_qn,
+                        art=art,
+                        existing_qn=existing.get(art.display_name),
+                    )
+                )
+
+        if spec.activate:
+            _activate_bundle(spec.name, ids["repo_qn"], skill_qn, spec.owner_user)
+
+    return results
+
+
+def create_skill_assets(
+    skills: Union[Dict[str, Any], List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Create one or multiple standalone Skill assets.
+
+    For Skills tied to a ContextRepository (the common case), use
+    create_context_repository_assets — it creates the paired bundle and the
+    artifacts as a single transaction, which is what the UI expects.
+
+    This tool covers the rarer case of SYSTEM or CUSTOM skills that exist
+    independently of a context repo.
+    """
+    data = skills if isinstance(skills, list) else [skills]
+    logger.info(f"Creating {len(data)} standalone Skill asset(s)")
+    specs = [SkillSpec(**item) for item in data]
+
+    asset_objs: List[Skill] = []
+    for spec in specs:
+        skill = Skill.creator(name=spec.name)
+        if spec.user_description is not None:
+            skill.user_description = spec.user_description
+        if spec.certificate_status:
+            skill.certificate_status = spec.certificate_status.value
+        if spec.skill_version is not None:
+            skill.skill_version = spec.skill_version
+        asset_objs.append(skill)
+
+    return save_assets(asset_objs)

--- a/modelcontextprotocol/tools/models.py
+++ b/modelcontextprotocol/tools/models.py
@@ -111,6 +111,61 @@ class DataProductSpec(BaseModel):
         return v
 
 
+class ContextBundleArtifactSpec(BaseModel):
+    """One file inside a ContextRepository bundle.
+
+    `display_name` is the relative path the Atlan UI renders in its file tree
+    (e.g. "soul.md", "skills/refunds/SKILL.md", "semantic_models/orders.yaml").
+    `content` is the UTF-8 file body — it is uploaded to object storage AND
+    stored on the SkillArtifact's `description` so the UI inline preview
+    works regardless of storage state.
+    """
+
+    display_name: str
+    content: str
+
+
+class ContextInputAssetRef(BaseModel):
+    """Reference to an Atlas asset linked to a ContextRepository as input context."""
+
+    guid: str
+    type_name: str  # e.g. "Table", "AtlasGlossaryTerm", "DataProduct"
+
+
+class ContextRepositorySpec(BaseModel):
+    """Payload model for creating a ContextRepository bundle.
+
+    A bundle is a ContextRepository + a paired Skill (contextOutputSkill,
+    skillType="CONTEXT_REPO") + a set of SkillArtifacts (the bundled files).
+    Files are persisted both as Atlas entities and as bytes in object storage
+    via a presigned-URL upload, matching the canonical agent-bundle flow.
+    """
+
+    name: str
+    user_description: Optional[str] = None
+    # Markdown body stored on ContextRepository.contextRepositoryAgentInstructions.
+    agent_instructions: Optional[str] = None
+    # Connection qualified_name used as the query execution engine.
+    target_connection_qualified_name: Optional[str] = None
+    # Input assets linked via contextInputAssets ({"guid","type_name"} pairs).
+    input_assets: Optional[List[ContextInputAssetRef]] = None
+    # File bundle (each becomes a SkillArtifact + an object-storage upload).
+    artifacts: Optional[List[ContextBundleArtifactSpec]] = None
+    # If True, flip lifecycle to ACTIVE and certificateStatus to VERIFIED at
+    # the end. `owner_user` (if given) is set as the only entry in ownerUsers.
+    activate: bool = False
+    owner_user: Optional[str] = None
+
+
+class SkillSpec(BaseModel):
+    """Payload model for creating a standalone Skill asset."""
+
+    name: str
+    user_description: Optional[str] = None
+    certificate_status: Optional[CertificateStatus] = None
+    skill_version: Optional[str] = None
+
+
 class DQRuleCondition(BaseModel):
     """Model representing a single data quality rule condition."""
 


### PR DESCRIPTION
## Summary

Adds two new MCP tools that let Claude Code (and any other MCP client) build agentic context directly on top of Atlan:

- **`create_context_repos`** — creates a full agent bundle in one call: a `ContextRepository` + a paired `contextOutputSkill` (`skillType=CONTEXT_REPO`) + the bundled files persisted as `SkillArtifact`s. Each file is uploaded to object storage via a presigned URL (`POST /api/service/files/presignedUrl` → S3 PUT) **and** stored on the artifact's `description` for inline preview. Repo + skill are created atomically via `/api/meta/entity/bulk` with cross-referencing negative guids so the `contextOutputSkill` relationship is set in a single round-trip. Optional `activate` flag flips the lifecycle to ACTIVE + `certificateStatus` to VERIFIED. Idempotent on re-publish (existing artifact qualifiedNames are reused).
- **`create_skills`** — covers the narrower case of SYSTEM / CUSTOM skills that exist independently of any repo.

The bundle flow mirrors the canonical persistence sequence used by `skills/agent-bundle/scripts/publish_to_atlan.py` (paired bulk create → per-artifact entity write → S3 PUT to presigned URL), so anything created via this MCP tool renders identically to the existing Context Studio repos.

## What changed

| File | Why |
|---|---|
| `modelcontextprotocol/tools/context_repo.py` | New module — implements the three-stage bundle persistence + standalone Skill creation. |
| `modelcontextprotocol/tools/models.py` | New Pydantic specs: `ContextRepositorySpec`, `ContextBundleArtifactSpec`, `ContextInputAssetRef`, `SkillSpec`. |
| `modelcontextprotocol/tools/__init__.py` | Export the new functions + specs. |
| `modelcontextprotocol/server.py` | Register `create_context_repos` + `create_skills` as MCP tools. |
| `modelcontextprotocol/pyproject.toml` | Bump `pyatlan>=9.4.1` (needed for the new typedefs). |
| `CLAUDE.md`, `modelcontextprotocol/README.md` | Document the new tools and how to discover existing agentic assets via `search_assets_tool`. |

## Test plan

- [x] `create_context_repos` with `artifacts=[soul.md, skills/refunds/SKILL.md, semantic_models/orders.yaml]` on a real tenant — repo + paired Skill + all 3 SkillArtifacts persisted.
- [x] Verify the UI content endpoint (`/context-studio-app/api/context-repos/{repo_id}/artifacts/{artifact_guid}/content`) returns the actual file bytes for every artifact.
- [x] Verify `contextOutputSkill` relationship is materialized on the catalog ContextRepository.
- [x] Verify nested folder paths (e.g. `skills/refunds/SKILL.md`) render as folders in the UI file tree.
- [x] `create_skills` for a standalone CUSTOM skill.
- [ ] Re-publish smoke (idempotency) — confirms the same `displayName` reuses its qualifiedName instead of duplicating.
- [ ] `activate=True` path — flips lifecycle to ACTIVE + VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/atlanhq/agent-toolkit/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->