### PR TITLE
docs(codex-plugin): document type='http' workaround for plugin-add bug

### DIFF
--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -20,6 +20,19 @@ codex plugin add atlan@atlan
 
 Quit and relaunch **Codex.app** — the Atlan plugin appears under **Plugins → Manage** (enabled, with the bundled MCP server registered). On first tool call, Codex runs OAuth against `mcp.atlan.com` to authenticate against your Atlan tenant.
 
+> **Known Codex CLI issue — verify `type = "http"` in your config.** As of current Codex CLI versions, `codex plugin add` does not preserve the `type` field from the plugin's bundled `.mcp.json` when writing to `~/.codex/config.toml`. Without `type = "http"`, Codex tries to launch the URL as a subprocess instead of opening an HTTP/OAuth connection — tool discovery returns zero tools, and the agent silently falls back to spawning `codex exec` child processes instead of calling MCP tools directly.
+>
+> After running `codex plugin add atlan@atlan`, open `~/.codex/config.toml` and confirm the section looks like this — manually add the `type` line if it's missing:
+>
+> ```toml
+> [mcp_servers.atlan]
+> type = "http"
+> url = "https://mcp.atlan.com/mcp"
+> enabled = true
+> ```
+>
+> **Fully quit and relaunch Codex** after editing — config is read once at process start, so hot edits won't take effect mid-session.
+
 ### From the official Codex Plugin Directory (once GA)
 
 When OpenAI opens self-serve publishing and Atlan is accepted into the curated Plugin Directory, install via **Codex.app → Plugins → search "Atlan" → Install**, or:


### PR DESCRIPTION
## Summary

Documents a known issue with Codex CLI's `codex plugin add` command — it drops the `type` field from the bundled `.mcp.json` when writing into `~/.codex/config.toml`. Without `type = \"http\"` Codex tries to launch the URL as a subprocess and tool discovery silently returns 0 tools.

## Why this matters

Empirically reproduced on a fresh install:

1. `codex plugin marketplace add https://github.com/atlanhq/agent-toolkit` ✅
2. `codex plugin add atlan@atlan` ✅ (plugin installed)
3. `~/.codex/config.toml` ends up with:
   ```toml
   [mcp_servers.atlan]
   url = \"https://mcp.atlan.com/mcp\"
   enabled = true
   # ↑ note: missing `type = \"http\"`
   ```
4. Codex session opens → user prompts \"Find tables...\" → agent says *\"I don't see an Atlan callable surfaced through tool discovery yet\"* and falls back to spawning `codex exec` child processes as a workaround.

## What this PR changes

Adds a callout in `codex-plugin/README.md` right after the `codex plugin add` instructions explaining:
- The exact symptom (zero tools loaded, `codex exec` workarounds)
- What `[mcp_servers.atlan]` should look like
- That Codex must be **fully quit and relaunched** after editing config.toml (mid-session edits don't take effect)

## What this PR is NOT

- The plugin's own `codex-plugin/.mcp.json` is already correct — it specifies `\"type\": \"http\"`. This is a Codex CLI bug, not a plugin source issue.
- No code changes. README-only.

## Follow-up

File an upstream issue against [openai/codex](https://github.com/openai/codex) so the workaround can eventually be removed. Until then, this README note saves the next user 30+ minutes of debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)