### PR TITLE
fix: replace data catalog copy with context layer positioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "engineering@atlan.com"
   },
   "metadata": {
-    "description": "Official Atlan plugins for Claude Code - data catalog, governance, and data mesh tools",
+    "description": "Official Atlan plugins for Claude Code - context layer, governance, and data mesh tools",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "atlan",
       "source": "./",
-      "description": "Atlan data catalog plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
+      "description": "Atlan context layer plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
       "version": "1.0.0",
       "author": {
         "name": "Atlan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atlan",
-  "description": "Atlan data catalog plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
+  "description": "Atlan context layer plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
   "version": "1.0.0",
   "author": {
     "name": "Atlan",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Atlan Plugin for Claude Code
 
-You have access to Atlan's data catalog through MCP tools. The Atlan MCP server connects via OAuth at `mcp.atlan.com/mcp` - no API keys required. Use these tools to help users search, explore, govern, and manage their data assets.
+You have access to Atlan's context layer through MCP tools. The Atlan MCP server connects via OAuth at `mcp.atlan.com/mcp` - no API keys required. Use these tools to help users search, explore, govern, and manage their data assets.
 
 ## Authentication
 

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -33,7 +33,7 @@
     "privacyPolicyURL": "https://atlan.com/privacy",
     "termsOfServiceURL": "https://atlan.com/terms",
     "defaultPrompt": [
-      "Find tables related to customer data in my Atlan catalog and summarize their lineage.",
+      "Find tables related to customer data in my Atlan context layer and summarize their lineage.",
       "List glossary terms tagged as PII in my catalog.",
       "Show upstream lineage for the orders fact table."
     ],

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -1,6 +1,6 @@
 # Atlan Cursor Plugin
 
-Registers Atlan's hosted MCP server (`https://mcp.atlan.com/mcp`) with Cursor so AI assistants can query your Atlan data catalog. OAuth is handled by Cursor against the server's discovery endpoint on first tool call — no API key or extra setup required.
+Registers Atlan's hosted MCP server (`https://mcp.atlan.com/mcp`) with Cursor so AI assistants can query your Atlan context layer. OAuth is handled by Cursor against the server's discovery endpoint on first tool call — no API key or extra setup required.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Replace "data catalog" / "Atlan catalog" with "context layer" across all user- and LLM-facing copy:

- `CLAUDE.md` — system prompt Claude sees on plugin install
- `.claude-plugin/plugin.json` + `marketplace.json` — Claude Code marketplace listing
- `cursor-plugin/README.md` — Cursor setup page
- `codex-plugin/.codex-plugin/plugin.json` — Codex example prompt

Part of a broader sweep to align all AI integration touchpoints with Atlan's context layer positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)