### PR TITLE
fix(claude-plugin): adopt context layer positioning, bump to 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Atlan plugins for Claude Code - context layer, governance, and data mesh tools",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "atlan",
       "source": "./",
-      "description": "Atlan context layer plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
-      "version": "1.0.0",
+      "description": "Atlan is the context layer for enterprise AI. Connect Claude Code to your organization's context repos — the knowledge, data, and semantics your AI agents need to build effectively. Use Atlan's agent skills to search & discover enterprise context, traverse end-to-end lineage, access governed data definitions and glossaries, execute SQL, curate your metadata graph, and ensure data quality — so every coding task in Claude Code is grounded in trusted organizational context.",
+      "version": "1.0.1",
       "author": {
         "name": "Atlan",
         "email": "engineering@atlan.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "atlan",
-  "description": "Atlan context layer plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language. Powered by the Atlan MCP server with semantic search, lineage traversal, glossary management, data quality rules, and more.",
-  "version": "1.0.0",
+  "description": "Atlan is the context layer for enterprise AI. Connect Claude Code to your organization's context repos — the knowledge, data, and semantics your AI agents need to build effectively. Use Atlan's agent skills to search & discover enterprise context, traverse end-to-end lineage, access governed data definitions and glossaries, execute SQL, curate your metadata graph, and ensure data quality — so every coding task in Claude Code is grounded in trusted organizational context.",
+  "version": "1.0.1",
   "author": {
     "name": "Atlan",
     "email": "engineering@atlan.com",

--- a/README.md
+++ b/README.md
@@ -24,17 +24,16 @@ You can find the documentation and setup instructions for the MCP server [here](
 
 ### Claude Code Plugin
 
-The official Atlan plugin for Claude Code. Search, explore, govern, and manage your data assets through natural language, powered by the Atlan MCP server.
+The official Atlan plugin for Claude Code — the context layer for enterprise AI. Connect Claude Code to your organization's data, metadata, and semantics so every coding task is grounded in trusted organizational context, powered by the Atlan MCP server.
 
 Connects to Atlan via OAuth at `mcp.atlan.com/mcp` - no API keys required.
 
-**Features:**
-- 15 MCP tools (12 enabled by default, 3 via feature flags)
-- **Search**: AI-powered semantic search across data assets
-- **Lineage**: Trace data flow upstream and downstream
-- **Governance**: Manage glossaries, terms, certifications
-- **Data Quality**: Create and schedule validation rules
-- **Data Mesh**: Organize domains and data products
+**Capabilities:**
+- **Search & discovery**: find and explore your enterprise context through semantic search
+- **Lineage**: trace data flow upstream and downstream
+- **Governance**: work with governed definitions, glossaries, terms, and certifications
+- **Data quality**: define and manage data quality rules
+- **Data mesh**: organize domains and data products
 
 **Setup:**
 ```bash


### PR DESCRIPTION
## What

Aligns the **Claude Code plugin** copy with the "context layer for enterprise AI" positioning already used by the Codex and Cursor plugins, and bumps the version.

- `.claude-plugin/plugin.json` — `description` → context-layer copy; `version` `1.0.0` → `1.0.1`
- `.claude-plugin/marketplace.json` — plugin-entry `description` → same copy; plugin `version` and marketplace `metadata.version` → `1.0.1`
- `README.md` — rewrite the "Claude Code Plugin" section to the context-layer framing and **capabilities only** (dropped the "15 MCP tools…" count, per-tool descriptions, and feature-flag/DSL/SQL internals). The claude.com directory long-body copy was seeded from this section, so this keeps future directory re-submissions consistent.

The new plugin description mirrors the Cursor/Codex wording, adapted to Claude Code:

> Atlan is the context layer for enterprise AI. Connect Claude Code to your organization's context repos — the knowledge, data, and semantics your AI agents need to build effectively. Use Atlan's agent skills to search & discover enterprise context, traverse end-to-end lineage, access governed data definitions and glossaries, execute SQL, curate your metadata graph, and ensure data quality — so every coding task in Claude Code is grounded in trusted organizational context.

## Why a patch bump

Metadata/copy-only change, no functional difference — patch (`1.0.1`). Bumping `version` lets installed plugins detect the update.

## On the logo (intentionally not included)

The original ask included adding the Atlan logo like the Codex/Cursor plugins. **Claude Code's plugin & marketplace schema has no logo/icon field today** — confirmed by inspecting `anthropics/claude-plugins-official` (0 of 612 files carry a brand logo; branded vendor manifests like Asana/Linear/GitHub are `name`+`description`+`author` only) and by the open feature requests `anthropics/claude-code#28187` and `#49040`. A logo file would be silently ignored, so none is added here. Revisit once Anthropic ships logo support.

## Follow-up needed to update the official directory (not possible from this repo)

What users see in the claude.com directory / in-app `/plugin` view is **Anthropic-controlled editorial copy**, not served from this repo:

- The directory entry in `anthropics/claude-plugins-official` carries its **own `description`** (still the old "data catalog" wording). Its `source` SHA is **auto-bumped** by Anthropic's bot to track this repo's default branch, but the bot **only updates the SHA, never the description**.
- The claude.com **short tagline** and **long body** live in Anthropic's directory CMS (no such fields exist in any repo).
- That repo **auto-closes external PRs** (`close-external-prs.yml`), so the directory copy cannot be changed via PR — it must go through the [plugin directory submission form](https://clau.de/plugin-directory-submission) / Anthropic partner contact. Drafted replacement copy lives in `.claude-plugin/DIRECTORY_COPY_SUBMISSION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai5b42pb5XY1McEo5mdwkj
