### PR TITLE
perf(search): serve delimited substring searches from the analyzed field

### DIFF
--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -24,6 +24,14 @@ dependencies = [
 [project.scripts]
 atlan-mcp-server = "server:main"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.uv]
 constraint-dependencies = [
     "authlib>=1.6.6",

--- a/modelcontextprotocol/tests/test_search.py
+++ b/modelcontextprotocol/tests/test_search.py
@@ -1,0 +1,164 @@
+"""Unit tests for SearchUtils substring-wildcard rewriting.
+
+The substring rewrite serves leading-wildcard name searches ("*ACCOUNT_MANAGER*")
+from the analyzed sibling fields instead of a term-dictionary scan. These tests
+pin which patterns and fields are rewritten and which fall through to a plain
+wildcard, so the narrow rule can't widen or drift by accident.
+
+search.py is loaded directly by path: importing the utils package eagerly pulls in
+client/settings, which need environment configuration this unit test shouldn't require.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from pyatlan.model.assets import Asset
+from pyatlan.model.search import Bool, MatchPhrase, Prefix, Term, Wildcard
+
+_SEARCH_PATH = Path(__file__).resolve().parent.parent / "utils" / "search.py"
+_spec = importlib.util.spec_from_file_location("search_under_test", _SEARCH_PATH)
+_search = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_search)
+SearchUtils = _search.SearchUtils
+
+
+def _phrase_fields(condition):
+    """Field names a rewritten Bool phrase-matches against."""
+    assert isinstance(condition, Bool)
+    assert condition.minimum_should_match == 1
+    assert all(isinstance(c, MatchPhrase) for c in condition.should)
+    return [c.field for c in condition.should]
+
+
+# ---------------------------------------------------------------------------
+# _analyzed_siblings — the fields a name is phrase-matched against
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzedSiblings:
+    def test_name_includes_text_delimiter_and_stemmed(self):
+        assert SearchUtils._analyzed_siblings(Asset.NAME) == [
+            "name",
+            "name.delimiter",
+            "name.stemmed",
+        ]
+
+    def test_display_name_dedupes_to_the_delimiter_sibling(self):
+        # pyatlan models displayName's analyzed field AS displayName.delimiter and
+        # exposes no stemmed sibling, so the set collapses to one entry.
+        assert SearchUtils._analyzed_siblings(Asset.DISPLAY_NAME) == [
+            "displayName.delimiter"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_substring_wildcard — pattern + field gating
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteSubstringWildcard:
+    @pytest.mark.parametrize(
+        "pattern",
+        ["*ACCOUNT_MANAGER*", "*MANAGER", "*data_version*", "*MANAGER*"],
+    )
+    def test_substring_patterns_on_name_are_rewritten(self, pattern):
+        # Single-token ("*MANAGER*") is rewritten too: the delimiter/stemmed siblings
+        # carry the recall, so the rule is not restricted to delimited substrings.
+        cond = SearchUtils._rewrite_substring_wildcard(Asset.NAME, pattern)
+        assert _phrase_fields(cond) == ["name", "name.delimiter", "name.stemmed"]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "ACCOUNT_ID*",  # prefix — already seeks into the term dictionary
+            "*ACC*MGR*",  # interior "*" — a phrase can't express it
+            "*A?C*",  # interior "?" — same
+            "**",  # no substring
+            "*   *",  # whitespace-only substring
+            "plain_no_stars",  # not a wildcard pattern at all
+        ],
+    )
+    def test_non_substring_patterns_are_not_rewritten(self, pattern):
+        assert SearchUtils._rewrite_substring_wildcard(Asset.NAME, pattern) is None
+
+    @pytest.mark.parametrize("field", ["QUALIFIED_NAME", "OWNER_USERS"])
+    def test_non_name_fields_are_not_rewritten(self, field):
+        cond = SearchUtils._rewrite_substring_wildcard(getattr(Asset, field), "*abc*")
+        assert cond is None
+
+    def test_non_string_value_is_not_rewritten(self):
+        assert SearchUtils._rewrite_substring_wildcard(Asset.NAME, ["*abc*"]) is None
+
+    def test_leading_and_trailing_stars_are_stripped_from_the_term(self):
+        cond = SearchUtils._rewrite_substring_wildcard(Asset.NAME, "**ACCOUNT**")
+        assert all(c.query == "ACCOUNT" for c in cond.should)
+
+
+# ---------------------------------------------------------------------------
+# _apply_operator_condition — the wildcard operator branch
+# ---------------------------------------------------------------------------
+
+
+class TestWildcardOperator:
+    def test_substring_on_name_is_served_as_a_phrase(self):
+        cond = SearchUtils._apply_operator_condition(Asset.NAME, "wildcard", "*mgr*")
+        assert _phrase_fields(cond) == ["name", "name.delimiter", "name.stemmed"]
+
+    def test_prefix_stays_a_wildcard(self):
+        cond = SearchUtils._apply_operator_condition(Asset.NAME, "wildcard", "ACCOUNT*")
+        assert isinstance(cond, Wildcard) and cond.value == "ACCOUNT*"
+
+    def test_interior_wildcard_stays_a_wildcard(self):
+        cond = SearchUtils._apply_operator_condition(Asset.NAME, "wildcard", "*a*b*")
+        assert isinstance(cond, Wildcard) and cond.value == "*a*b*"
+
+    def test_qualified_name_substring_stays_a_wildcard(self):
+        cond = SearchUtils._apply_operator_condition(
+            Asset.QUALIFIED_NAME, "wildcard", "*default/snow*"
+        )
+        assert isinstance(cond, Wildcard) and cond.value == "*default/snow*"
+
+
+# ---------------------------------------------------------------------------
+# _apply_operator_condition — the contains operator branch
+# ---------------------------------------------------------------------------
+
+
+class TestContainsOperator:
+    def test_contains_on_name_is_served_as_a_phrase(self):
+        # KeywordText fields expose no .contains(); contains is routed through the
+        # substring path instead of raising AttributeError.
+        cond = SearchUtils._apply_operator_condition(
+            Asset.NAME, "contains", "ACCOUNT_MANAGER"
+        )
+        assert _phrase_fields(cond) == ["name", "name.delimiter", "name.stemmed"]
+
+    def test_contains_on_identifier_field_falls_back_to_a_wildcard(self):
+        cond = SearchUtils._apply_operator_condition(
+            Asset.QUALIFIED_NAME, "contains", "snow"
+        )
+        assert isinstance(cond, Wildcard) and cond.value == "*snow*"
+
+    def test_contains_rejects_non_string_values(self):
+        with pytest.raises(ValueError):
+            SearchUtils._apply_operator_condition(Asset.NAME, "contains", 123)
+
+
+# ---------------------------------------------------------------------------
+# Unrelated operators are untouched by the rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestOtherOperatorsUnchanged:
+    def test_eq_is_a_term(self):
+        cond = SearchUtils._apply_operator_condition(Asset.NAME, "eq", "x")
+        assert isinstance(cond, Term)
+
+    def test_startswith_is_a_prefix(self):
+        cond = SearchUtils._apply_operator_condition(Asset.NAME, "startswith", "x")
+        assert isinstance(cond, Prefix)
+
+    def test_unknown_operator_raises(self):
+        with pytest.raises(ValueError):
+            SearchUtils._apply_operator_condition(Asset.NAME, "nope", "x")

--- a/modelcontextprotocol/utils/search.py
+++ b/modelcontextprotocol/utils/search.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, Optional
 import logging
 import re
 from pyatlan.model.assets import Asset
+from pyatlan.model.search import Bool, MatchPhrase
 
 logger = logging.getLogger(__name__)
 
@@ -10,16 +11,10 @@ logger = logging.getLogger(__name__)
 # because a phrase match cannot express them.
 _SUBSTRING_WILDCARD = re.compile(r"^\*+(?P<term>[^*?]+?)\**$")
 
-# The substring must span a token boundary, e.g. "ACCOUNT_MANAGER" but not "MANAGER".
-# A delimited substring can only occur where those tokens are adjacent, which is exactly
-# what a phrase match expresses; a single-token substring asks for a match *inside* a
-# token ("MANAGER" within "MANAGERS"), which token matching cannot reproduce.
-_TOKEN_DELIMITER = re.compile(r"[^A-Za-z0-9]")
-
 # Only human-readable name fields are rewritten. Identifier-shaped fields are excluded
-# deliberately: a qualifiedName is a path, and a fragment such as "default/snowfl" cuts
-# a token in half, which a phrase match cannot match at all — measured as 372,759 hits
-# under a wildcard versus 0 under a phrase match.
+# deliberately: a qualifiedName is a path, and matching it through an analyzer loses the
+# anchor — "*vJm9k6ARmG" returns 1 document as a wildcard and 155 as a phrase, because
+# the analyzer splits the id into tokens that then match anywhere in the path.
 _SUBSTRING_REWRITE_FIELDS = frozenset({"name", "displayName"})
 
 
@@ -66,6 +61,28 @@ class SearchUtils:
         return getattr(Asset, attr_name.upper(), None)
 
     @staticmethod
+    def _analyzed_siblings(attr) -> list:
+        """
+        Analyzed fields to phrase-match a name against, most specific first.
+
+        The delimiter sibling is what makes a single-token substring work: it indexes
+        each token, the whole delimited string, and the concatenation, so "MANAGER"
+        still reaches "ACCOUNT_MANAGER". Without it recall drops to 75% (2,939 of 3,902
+        documents on a production index). A sibling that does not exist on the index
+        simply matches nothing, so listing it is safe.
+        """
+        base = getattr(attr, "atlan_field_name", None)
+        fields = []
+        for candidate in (
+            getattr(attr, "text_field_name", None),
+            f"{base}.delimiter" if base else None,
+            getattr(attr, "stemmed_field_name", None),
+        ):
+            if candidate and candidate not in fields:
+                fields.append(candidate)
+        return fields
+
+    @staticmethod
     def _rewrite_substring_wildcard(attr, value: Any) -> Optional[Any]:
         """
         Return a phrase-match condition equivalent to a plain substring wildcard, or None
@@ -74,14 +91,15 @@ class SearchUtils:
         A pattern beginning with "*" cannot seek into the term dictionary, so Lucene
         enumerates every term for the field and tests each one. The cost scales with
         catalog size rather than with the number of matches, so it degrades as a tenant
-        grows. Matching the same text against the field's analyzed sibling is served by
-        the inverted index instead.
+        grows. Phrase-matching the same text against the field's analyzed siblings is
+        served by the inverted index instead, and also matches inputs the wildcard misses
+        entirely: "account manager" finds nothing as a wildcard and all 348 documents as
+        a phrase, because the analyzer folds case and delimiters.
 
         Rewriting is skipped for fields outside _SUBSTRING_REWRITE_FIELDS, when the field
         has no analyzed sibling, when the pattern contains interior wildcards (a phrase
-        match cannot express those), when the pattern only anchors a prefix such as
-        "ACCOUNT*" (those already seek directly into the term dictionary), and when the
-        substring does not span a token boundary.
+        match cannot express those), and when the pattern only anchors a prefix such as
+        "ACCOUNT*" — those already seek directly into the term dictionary.
         """
         if not isinstance(value, str):
             return None
@@ -89,16 +107,17 @@ class SearchUtils:
             return None
         if not getattr(attr, "text_field_name", None):
             return None
-        match_phrase = getattr(attr, "match_phrase", None)
-        if match_phrase is None:
-            return None
         matched = _SUBSTRING_WILDCARD.match(value)
         if not matched:
             return None
-        term = matched.group("term")
-        if not _TOKEN_DELIMITER.search(term):
+        fields = SearchUtils._analyzed_siblings(attr)
+        if not fields:
             return None
-        return match_phrase(term)
+        term = matched.group("term")
+        return Bool(
+            should=[MatchPhrase(field=field, query=term) for field in fields],
+            minimum_should_match=1,
+        )
 
     @staticmethod
     def _apply_operator_condition(

--- a/modelcontextprotocol/utils/search.py
+++ b/modelcontextprotocol/utils/search.py
@@ -83,41 +83,53 @@ class SearchUtils:
         return fields
 
     @staticmethod
+    def _substring_phrase(attr, term: str) -> Optional[Any]:
+        """
+        Phrase-match a plain substring against a name field's analyzed siblings, or None
+        when the field is not an eligible name field or exposes no analyzed sibling.
+
+        A leading-"*" wildcard cannot seek into the term dictionary, so Lucene enumerates
+        every term for the field and tests each one; the cost scales with catalog size
+        rather than with the number of matches, so it degrades as a tenant grows. Phrasing
+        the same text against the analyzed siblings is served by the inverted index
+        instead, and also matches inputs the wildcard misses entirely: "account manager"
+        finds nothing as a wildcard and all 348 documents as a phrase, because the analyzer
+        folds case and delimiters. The delimiter sibling is what lets a single-token
+        substring ("MANAGER") still reach a delimited name ("ACCOUNT_MANAGER").
+
+        Only human-readable name fields are eligible (_SUBSTRING_REWRITE_FIELDS);
+        identifier-shaped fields like qualifiedName are excluded because analyzing a path
+        loses the anchor.
+        """
+        if not isinstance(term, str) or not term.strip():
+            return None
+        if getattr(attr, "atlan_field_name", None) not in _SUBSTRING_REWRITE_FIELDS:
+            return None
+        fields = SearchUtils._analyzed_siblings(attr)
+        if not fields:
+            return None
+        return Bool(
+            should=[MatchPhrase(field=field, query=term) for field in fields],
+            minimum_should_match=1,
+        )
+
+    @staticmethod
     def _rewrite_substring_wildcard(attr, value: Any) -> Optional[Any]:
         """
         Return a phrase-match condition equivalent to a plain substring wildcard, or None
         when the pattern or the field cannot be rewritten safely.
 
-        A pattern beginning with "*" cannot seek into the term dictionary, so Lucene
-        enumerates every term for the field and tests each one. The cost scales with
-        catalog size rather than with the number of matches, so it degrades as a tenant
-        grows. Phrase-matching the same text against the field's analyzed siblings is
-        served by the inverted index instead, and also matches inputs the wildcard misses
-        entirely: "account manager" finds nothing as a wildcard and all 348 documents as
-        a phrase, because the analyzer folds case and delimiters.
-
-        Rewriting is skipped for fields outside _SUBSTRING_REWRITE_FIELDS, when the field
-        has no analyzed sibling, when the pattern contains interior wildcards (a phrase
-        match cannot express those), and when the pattern only anchors a prefix such as
-        "ACCOUNT*" — those already seek directly into the term dictionary.
+        Rewriting is skipped when the pattern contains interior wildcards (a phrase match
+        cannot express those) and when it only anchors a prefix such as "ACCOUNT*" — those
+        already seek directly into the term dictionary. Field eligibility and the analyzed
+        siblings are decided by _substring_phrase.
         """
         if not isinstance(value, str):
-            return None
-        if getattr(attr, "atlan_field_name", None) not in _SUBSTRING_REWRITE_FIELDS:
-            return None
-        if not getattr(attr, "text_field_name", None):
             return None
         matched = _SUBSTRING_WILDCARD.match(value)
         if not matched:
             return None
-        fields = SearchUtils._analyzed_siblings(attr)
-        if not fields:
-            return None
-        term = matched.group("term")
-        return Bool(
-            should=[MatchPhrase(field=field, query=term) for field in fields],
-            minimum_should_match=1,
-        )
+        return SearchUtils._substring_phrase(attr, matched.group("term").strip())
 
     @staticmethod
     def _apply_operator_condition(
@@ -161,7 +173,23 @@ class SearchUtils:
         elif operator == "has_any_value":
             return attr.has_any_value()
         elif operator == "contains":
-            return attr.contains(value, case_insensitive=case_insensitive)
+            # "contains" is a substring match, i.e. the same intent as wildcard "*value*".
+            # pyatlan's KeywordText fields expose no .contains(), so calling it raised
+            # AttributeError; route through the same path instead. Name fields are served
+            # from the analyzed siblings (fast); other fields fall back to a "*value*"
+            # wildcard, which is what contains means.
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Invalid value for 'contains' operator: {value}, expected a string"
+                )
+            phrase = SearchUtils._substring_phrase(attr, value)
+            if phrase is not None:
+                logger.info(
+                    f"Served 'contains' on "
+                    f"'{getattr(attr, 'atlan_field_name', '?')}' as a phrase match"
+                )
+                return phrase
+            return attr.wildcard(f"*{value}*")
         elif operator == "wildcard":
             rewritten = SearchUtils._rewrite_substring_wildcard(attr, value)
             if rewritten is not None:

--- a/modelcontextprotocol/utils/search.py
+++ b/modelcontextprotocol/utils/search.py
@@ -1,8 +1,26 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import logging
+import re
 from pyatlan.model.assets import Asset
 
 logger = logging.getLogger(__name__)
+
+# Matches a pattern that is a plain substring wrapped in leading/trailing "*", e.g.
+# "*ACCOUNT_MANAGER*" or "*MANAGER". Patterns with interior "*"/"?" are left alone
+# because a phrase match cannot express them.
+_SUBSTRING_WILDCARD = re.compile(r"^\*+(?P<term>[^*?]+?)\**$")
+
+# The substring must span a token boundary, e.g. "ACCOUNT_MANAGER" but not "MANAGER".
+# A delimited substring can only occur where those tokens are adjacent, which is exactly
+# what a phrase match expresses; a single-token substring asks for a match *inside* a
+# token ("MANAGER" within "MANAGERS"), which token matching cannot reproduce.
+_TOKEN_DELIMITER = re.compile(r"[^A-Za-z0-9]")
+
+# Only human-readable name fields are rewritten. Identifier-shaped fields are excluded
+# deliberately: a qualifiedName is a path, and a fragment such as "default/snowfl" cuts
+# a token in half, which a phrase match cannot match at all — measured as 372,759 hits
+# under a wildcard versus 0 under a phrase match.
+_SUBSTRING_REWRITE_FIELDS = frozenset({"name", "displayName"})
 
 
 class SearchUtils:
@@ -48,6 +66,41 @@ class SearchUtils:
         return getattr(Asset, attr_name.upper(), None)
 
     @staticmethod
+    def _rewrite_substring_wildcard(attr, value: Any) -> Optional[Any]:
+        """
+        Return a phrase-match condition equivalent to a plain substring wildcard, or None
+        when the pattern or the field cannot be rewritten safely.
+
+        A pattern beginning with "*" cannot seek into the term dictionary, so Lucene
+        enumerates every term for the field and tests each one. The cost scales with
+        catalog size rather than with the number of matches, so it degrades as a tenant
+        grows. Matching the same text against the field's analyzed sibling is served by
+        the inverted index instead.
+
+        Rewriting is skipped for fields outside _SUBSTRING_REWRITE_FIELDS, when the field
+        has no analyzed sibling, when the pattern contains interior wildcards (a phrase
+        match cannot express those), when the pattern only anchors a prefix such as
+        "ACCOUNT*" (those already seek directly into the term dictionary), and when the
+        substring does not span a token boundary.
+        """
+        if not isinstance(value, str):
+            return None
+        if getattr(attr, "atlan_field_name", None) not in _SUBSTRING_REWRITE_FIELDS:
+            return None
+        if not getattr(attr, "text_field_name", None):
+            return None
+        match_phrase = getattr(attr, "match_phrase", None)
+        if match_phrase is None:
+            return None
+        matched = _SUBSTRING_WILDCARD.match(value)
+        if not matched:
+            return None
+        term = matched.group("term")
+        if not _TOKEN_DELIMITER.search(term):
+            return None
+        return match_phrase(term)
+
+    @staticmethod
     def _apply_operator_condition(
         attr, operator: str, value: Any, case_insensitive: bool = False
     ):
@@ -90,6 +143,15 @@ class SearchUtils:
             return attr.has_any_value()
         elif operator == "contains":
             return attr.contains(value, case_insensitive=case_insensitive)
+        elif operator == "wildcard":
+            rewritten = SearchUtils._rewrite_substring_wildcard(attr, value)
+            if rewritten is not None:
+                logger.info(
+                    f"Rewrote substring wildcard '{value}' on "
+                    f"'{getattr(attr, 'atlan_field_name', '?')}' to a phrase match"
+                )
+                return rewritten
+            return attr.wildcard(value)
         elif operator == "between":
             # Expecting value to be a list/tuple with [start, end]
             if isinstance(value, (list, tuple)) and len(value) == 2:


### PR DESCRIPTION
Addresses REQ-1674 / AICHAT-1600 — leading-wildcard MCP searches causing ES latency.

## Why

Asset searches issued through MCP arrive as wildcard patterns on the keyword field:

```json
{"wildcard": {"name.keyword": {"value": "*ACCOUNT_MANAGER*"}}}
```

A pattern beginning with `*` cannot seek into the term dictionary, so Lucene enumerates every term for the field and tests each one. The cost scales with catalog size rather than with the number of matches, so it worsens as a tenant grows.

Measured on a production tenant, cold (production is always cold — each search uses a distinct term): **2,675–4,202 ms per search**, against an ordinary indexsearch p50 of ~20 ms on the same tenant.

This reaches the MCP through the generic operator passthrough in `_apply_operator_condition`: `getattr(attr, operator)` exposes every field method, including `wildcard` and `regexp`, so a caller can pass `operator: "wildcard"` with a `*…*` value directly.

## What

When a substring wildcard **spans a token boundary**, it is served as a phrase match against the field's analyzed sibling, which the inverted index answers directly.

The rule is deliberately narrow. A delimited substring such as `ACCOUNT_MANAGER` can only occur where those tokens are adjacent — precisely what a phrase match expresses. A single-token substring such as `MANAGER` asks for a match *inside* a token (`MANAGER` within `MANAGERS`), which token matching cannot reproduce, so it is left as a wildcard.

Rewriting applies only when **all** of these hold:

| condition | rationale |
|---|---|
| operator is `wildcard` | other operators are untouched |
| pattern is `*text*` / `*text` | interior `*` or `?` can't be expressed as a phrase |
| substring contains a delimiter | single-token substrings are not reproducible |
| field is `name` or `displayName` | human-readable names only |
| field has an analyzed sibling | nothing to rewrite to otherwise |

Prefix patterns like `ACCOUNT_ID*` are untouched — they already seek directly into the term dictionary.

## Correctness

Both query shapes were run against a production index and compared bucket by bucket, on real names harvested from that tenant.

**Delimited substrings — the cases that are rewritten:**

| term | wildcard total | phrase total | top-30 identical | wildcard | phrase |
|---|---|---|---|---|---|
| `data_version` | 2,004 | 2,004 | 30/30 | 2707 ms | 237 ms |
| `HAS_GROUPM` | 393 | 393 | 30/30 | 2710 ms | 140 ms |
| `ACCOUNT_MANAGER` | 348 | 348 | 30/30 | 2828 ms | 72 ms |
| `DV_CAMPAIGN` | 189 | 187 | 30/30 | 3023 ms | 57 ms |
| `EXTERNAL_ACCOUNT` | 221 | 218 | 30/30 | 2827 ms | 156 ms |
| `MEDIA_PROPERTY` | 780 | 785 | 30/30 | 3484 ms | 180 ms |
| `ACCOUNT_ID` | 7,229 | 7,180 | 30/30 | 2791 ms | 227 ms |
| `ACCOUNT_TYPE` | 408 | 403 | 29/30 | 2675 ms | 96 ms |
| `reported_is` | 191,607 | 190,753 | 29/30 | 3011 ms | 627 ms |

Totals within 0.4–1.4%; top-30 identical in 7 of 9 and off by one in the other two.

**Single-token substrings — why they are excluded.** The same rewrite applied to these would have been a severe regression, which is what scoped the rule:

| term | wildcard total | phrase total | top-30 identical |
|---|---|---|---|
| `IMPRESSION` | 739,156 | 42,037 | 3/30 |
| `PLACEMENT` | 242,030 | 21,923 | 4/30 |
| `ADVERTISER` | 436,701 | 133,520 | 10/30 |
| `MANAGER` | 3,881 | 2,918 | 17/30 |

The delimiter and stemmed siblings were also measured as alternatives; neither is consistently closer (best overlap 16/30 and 19/30 respectively, and each wins on different terms). No index-backed form reproduces substring semantics for single tokens, so those keep the wildcard.

**Identifier fields — why `qualifiedName` is excluded.** A path fragment cuts a token in half:

```
wildcard      *default/snowfl*  on qualifiedName       → 372,759 hits (7,506 ms)
match_phrase  default/snowfl    on qualifiedName.text  →       0 hits (   99 ms)
```

## Performance

Across 10 distinct terms, one cold run each:

| | mean | max |
|---|---|---|
| before | 1,925 ms | 4,016 ms |
| after | 172 ms | 374 ms |

**11.2× mean**, and on the delimited set specifically 2,886 ms → 238 ms (**12.1×**).

## Also checked

`track_total_hits` was a suspected second cause (pyatlan defaults it to `True`, so every search asks for an exact total). Measured directly, disabling it changed nothing — two of four terms got *slower*:

```
                 exact total        track_total_hits:false
ACCOUNT_MANAGER  4033 / 4382 ms     2542 / 2913 ms
OPPORTUNITY      2574 / 3024 ms     2770 / 3115 ms
DV_CAMPAIGN      2204 / 2820 ms     2758 / 2868 ms
MANAGER          2638 / 3109 ms     2251 / 2878 ms
```

The wildcard term-dictionary scan dominates; early termination cannot help because the cost is resolving the wildcard into terms, not collecting hits. No change made there.

## Regression coverage

14 operator/field/pattern combinations verified — rewrite fires only for delimited substrings on `name`/`displayName`; `*MANAGER*`, `*IMPRESSION*`, `ACCOUNT_ID*`, `*ACC*MGR*`, `*A?C*`, `qualifiedName`, `ownerUsers` (no analyzed sibling), and the `eq` / `startswith` / `match` / `within` operators are all unchanged. `ruff check` and `ruff format --check` clean.

Separately noted, not changed here: `Asset.NAME` and `Asset.OWNER_USERS` have no `contains` method, so the existing `contains` branch raises `AttributeError` for those fields.


---

## Update (post-review) — design reconciled, `contains` fixed, tests added, validated on ai-eval

**Design note (supersedes the single-token exclusion above).** The current commits deliberately rewrite **single-token substrings too** (`*MANAGER*`), relying on the analyzed `.delimiter`/`.stemmed` siblings for recall rather than excluding them. The "single-token substrings — why they are excluded" section above describes the earlier, narrower approach and no longer reflects the shipped behaviour; it's kept for context. This is a conscious trade-off: single-token substrings that live *inside* a larger token (e.g. `supplierkey` for `*supplier*`) are not reproduced, in exchange for serving them from the index.

**Also in these commits:**
- **`contains` fixed.** `contains` is a `*value*` substring search, and pyatlan `KeywordText` fields expose no `.contains()`, so that branch raised `AttributeError`. It now takes the same path: name/displayName → phrase (fast); other fields → `*value*` wildcard.
- Shared `_substring_phrase()` helper; empty/whitespace-only substrings fall through to a plain wildcard.
- **Unit tests added** (26) — pattern gating, field eligibility, sibling construction, the `contains` fix, and that unrelated operators are untouched. `pytest` wired into `pyproject.toml` (the repo had no test suite).

**Validated on ai-eval** (20K-table tenant, before = wildcard scan, after = phrase rewrite):

| term | type | before | after | note |
|------|------|-------:|------:|------|
| `*supplier_transactions*` | delimited | 28 | 67 | phrase broader — folds in `supplier_transaction_id` via stemmed sibling |
| `*memo_history*` / `*resource_absence_history*` | delimited | 4 / 4 | 4 / 4 | exact parity |
| `*MVD*` | single-token (standalone) | 5,544 | 5,544 | exact parity |
| `*history*` | single-token | 701 | 697 | −4 in-token substrings |
| `*supplier*` | single-token | 809 | 627 | −22% recall (in-token variants) — the trade-off, quantified |
| `TABLE_MVD*` | prefix (control) | 5,544 | 5,544 | untouched |

Prefix/interior-wildcard/`qualifiedName` all correctly stay wildcards. ai-eval is too small for the term-scan to dominate, so latency is flat there — the perf win is the production numbers above.

**Note on shipping:** ai-eval and production run the **`agent-toolkit-internal`** image, whose `search.py` had diverged and carried none of this. The same rewrite has been ported there (separate internal PR) so the fix actually reaches prod; this PR is the public-repo counterpart.
