### PR TITLE
fix(search): use wildcard query for contains operator

### DIFF
--- a/modelcontextprotocol/utils/search.py
+++ b/modelcontextprotocol/utils/search.py
@@ -89,7 +89,9 @@ class SearchUtils:
         elif operator == "has_any_value":
             return attr.has_any_value()
         elif operator == "contains":
-            return attr.contains(value, case_insensitive=case_insensitive)
+            # Asset attributes (e.g. KeywordTextStemmedField) have no `.contains()` method;
+            # a substring match is expressed as a wildcard query instead.
+            return attr.wildcard(f"*{value}*", case_insensitive=case_insensitive)
         elif operator == "between":
             # Expecting value to be a list/tuple with [start, end]
             if isinstance(value, (list, tuple)) and len(value) == 2:


### PR DESCRIPTION
## Summary
- Fixes #157 — `search_assets_tool` (and any DSL/tool code that reaches `SearchUtils._apply_operator_condition`) raised `'KeywordTextStemmedField' object has no attribute 'contains'` whenever a `contains` condition was used (e.g. natural-language queries like "find 5 tables about customers" that get translated into a `contains` filter on `name`).
- Root cause: `pyatlan`'s searchable field classes (`KeywordField`, `TextField`, `KeywordTextField`, `KeywordTextStemmedField`, etc.) never define a `.contains()` method — only `LineageFilterField` subclasses do. So `attr.contains(...)` in `modelcontextprotocol/utils/search.py` always fails for the common asset attributes (`NAME`, `DESCRIPTION`, ...), which are `KeywordTextStemmedField`.
- Fix: map the `contains` operator to `attr.wildcard(f"*{value}*", case_insensitive=case_insensitive)`, which `KeywordField` (and therefore `KeywordTextField`/`KeywordTextStemmedField`) does support, and produces the intended substring-match semantics.

## Test plan
- [x] `python -m py_compile modelcontextprotocol/utils/search.py`
- [x] Verified against the installed `pyatlan` package source (`pyatlan/model/fields/atlan_fields.py`) that `contains()` is not defined on `KeywordField`/`TextField`/`KeywordTextField`/`KeywordTextStemmedField`, and that `wildcard()` is defined on `KeywordField` (inherited by `KeywordTextStemmedField`).
- [ ] No existing test suite in this repo to extend (tracked separately in #36); happy to add a unit test around `SearchUtils._apply_operator_condition` if the maintainers want one for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)