### PR TITLE
fix(query): enforce read-only SQL contract in query_asset_tool

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -225,6 +225,7 @@ You can restrict any of the following tools:
 - `update_dq_rules_tool` - Data quality rule updates
 - `schedule_dq_rules_tool` - Data quality rule scheduling
 - `delete_dq_rules_tool` - Data quality rule deletion
+- `query_asset_tool` - SQL query execution against connected data sources
 
 ### Common Use Cases
 
@@ -233,6 +234,10 @@ Restrict all write operations:
 ```
 RESTRICTED_TOOLS=update_assets_tool,create_glossaries,create_glossary_categories,create_glossary_terms,create_dq_rules_tool,update_dq_rules_tool,schedule_dq_rules_tool,delete_dq_rules_tool
 ```
+Note: `query_asset_tool` itself already rejects non-SELECT/WITH/SHOW/DESCRIBE/EXPLAIN/VALUES SQL
+(INSERT, UPDATE, DELETE, DDL, multi-statement queries, etc. are all rejected before execution).
+Add `query_asset_tool` to `RESTRICTED_TOOLS` above if you want to disable SQL execution entirely,
+for example in a deployment where even read-only SQL access to source systems is undesirable.
 
 #### Disable DSL Queries
 For security or performance reasons:

--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -21,6 +21,11 @@ dependencies = [
     "uvicorn>=0.35.0"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
 [project.scripts]
 atlan-mcp-server = "server:main"
 
@@ -40,6 +45,10 @@ constraint-dependencies = [
 "Bug Tracker" = "https://github.com/atlanhq/agent-toolkit/issues"
 "Source" = "https://github.com/atlanhq/agent-toolkit.git"
 "Changelog" = "https://github.com/atlanhq/agent-toolkit/blob/main/CHANGELOG.md"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
 
 [tool.hatch.version]
 path = "version.py"

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -681,6 +681,8 @@ def query_asset_tool(
     to execute SQL against connected data sources.
 
     CRITICAL: Use READ-ONLY queries to retrieve data. Write and modify queries are not supported by this tool.
+    This is enforced: SELECT/WITH/SHOW/DESCRIBE/EXPLAIN/VALUES statements are allowed, everything else
+    (INSERT, UPDATE, DELETE, DDL, multi-statement SQL, etc.) is rejected before execution.
 
 
     Args:

--- a/modelcontextprotocol/tests/test_query.py
+++ b/modelcontextprotocol/tests/test_query.py
@@ -1,0 +1,55 @@
+"""Tests that query_asset enforces the read-only SQL contract before touching the client."""
+
+from unittest.mock import patch
+
+from tools.query import query_asset
+
+
+def test_rejects_write_sql_without_calling_client():
+    with patch("tools.query.get_atlan_client") as mock_get_client:
+        result = query_asset(
+            sql="DROP TABLE PAGES",
+            connection_qualified_name="default/snowflake/1657275059",
+        )
+
+    assert result["success"] is False
+    assert (
+        "read-only" in result["error"].lower()
+        or "not allowed" in result["error"].lower()
+    )
+    mock_get_client.assert_not_called()
+
+
+def test_rejects_multi_statement_sql_without_calling_client():
+    with patch("tools.query.get_atlan_client") as mock_get_client:
+        result = query_asset(
+            sql="SELECT * FROM PAGES; DROP TABLE PAGES;",
+            connection_qualified_name="default/snowflake/1657275059",
+        )
+
+    assert result["success"] is False
+    mock_get_client.assert_not_called()
+
+
+def test_allows_select_and_calls_client():
+    with (
+        patch("tools.query.get_atlan_client") as mock_get_client,
+        patch("tools.query.QueryRequest") as mock_query_request,
+    ):
+        mock_client = mock_get_client.return_value
+        mock_client.queries.stream.return_value = {"rows": []}
+
+        result = query_asset(
+            sql="SELECT * FROM PAGES LIMIT 10",
+            connection_qualified_name="default/snowflake/1657275059",
+            default_schema="LANDING.FRONTEND_PROD",
+        )
+
+    assert result["success"] is True
+    mock_get_client.assert_called_once()
+    mock_query_request.assert_called_once_with(
+        sql="SELECT * FROM PAGES LIMIT 10",
+        data_source_name="default/snowflake/1657275059",
+        default_schema="LANDING.FRONTEND_PROD",
+    )
+    mock_client.queries.stream.assert_called_once()

--- a/modelcontextprotocol/tests/test_sql_validator.py
+++ b/modelcontextprotocol/tests/test_sql_validator.py
@@ -1,0 +1,51 @@
+"""Tests for the query_asset_tool read-only SQL enforcement."""
+
+import pytest
+
+from utils.sql_validator import validate_read_only_sql
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM PAGES LIMIT 10",
+        'select count(*) from "LANDING"."FRONTEND_PROD"."PAGES"',
+        "  SELECT page_type FROM PAGES WHERE created_date >= '2024-01-01'  ",
+        "WITH recent AS (SELECT * FROM PAGES) SELECT * FROM recent",
+        "SHOW TABLES",
+        "DESCRIBE PAGES",
+        "DESC PAGES",
+        "EXPLAIN SELECT * FROM PAGES",
+        "VALUES (1, 2, 3)",
+        "SELECT * FROM PAGES WHERE comment = 'please insert here'",
+        "SELECT * FROM PAGES; ",  # single trailing semicolon is fine
+    ],
+)
+def test_allows_read_only_statements(sql):
+    is_valid, error = validate_read_only_sql(sql)
+    assert is_valid is True
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "INSERT INTO PAGES (id) VALUES (1)",
+        "UPDATE PAGES SET views = 0",
+        "DELETE FROM PAGES",
+        "DROP TABLE PAGES",
+        "TRUNCATE TABLE PAGES",
+        "ALTER TABLE PAGES ADD COLUMN foo INT",
+        "CREATE TABLE PAGES (id INT)",
+        "GRANT SELECT ON PAGES TO some_role",
+        "SELECT * INTO new_table FROM PAGES",
+        "WITH t AS (INSERT INTO PAGES (id) VALUES (1) RETURNING *) SELECT * FROM t",
+        "SELECT * FROM PAGES; DROP TABLE PAGES;",
+        "",
+        "   ",
+    ],
+)
+def test_rejects_non_read_only_statements(sql):
+    is_valid, error = validate_read_only_sql(sql)
+    assert is_valid is False
+    assert error

--- a/modelcontextprotocol/tools/query.py
+++ b/modelcontextprotocol/tools/query.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, Optional
 
 from client import get_atlan_client
 from pyatlan.model.query import QueryRequest
+from utils.sql_validator import validate_read_only_sql
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -72,6 +73,18 @@ def query_asset(
                 "success": False,
                 "data": None,
                 "error": error_msg,
+                "query_info": {},
+            }
+
+        # Enforce the tool's documented read-only contract before we ever
+        # build or execute a QueryRequest.
+        is_read_only, validation_error = validate_read_only_sql(sql)
+        if not is_read_only:
+            logger.error(f"Rejected non-read-only SQL query: {validation_error}")
+            return {
+                "success": False,
+                "data": None,
+                "error": validation_error,
                 "query_info": {},
             }
 

--- a/modelcontextprotocol/utils/sql_validator.py
+++ b/modelcontextprotocol/utils/sql_validator.py
@@ -1,0 +1,145 @@
+"""
+Lightweight read-only SQL validator for ``query_asset_tool``.
+
+``query_asset_tool`` is documented as read-only, but the underlying Atlan
+query service will happily execute any SQL it is given. This module provides
+a conservative, dependency-free check that rejects statements which are not
+plainly read-only *before* a ``QueryRequest`` is ever built, so the tool's
+documented contract is enforced in code rather than only in the docstring.
+
+This is intentionally conservative rather than a full SQL parser: it is
+designed to catch write/DDL statements and multi-statement payloads, not to
+validate SQL correctness. Anything it can't confidently classify as
+read-only is rejected.
+"""
+
+import re
+
+# Statement keywords that are allowed to start a read-only query.
+_ALLOWED_LEADING_KEYWORDS = {
+    "select",
+    "with",
+    "show",
+    "describe",
+    "desc",
+    "explain",
+    "values",
+}
+
+# Keywords that indicate a write, DDL, or session/administrative
+# statement. These are rejected wherever they appear (not just as the
+# leading keyword) so that write statements hidden inside CTEs or
+# subqueries (e.g. ``WITH t AS (INSERT INTO ... RETURNING *) SELECT * FROM t``)
+# are also caught.
+_DISALLOWED_KEYWORDS = {
+    "insert",
+    "update",
+    "delete",
+    "merge",
+    "upsert",
+    "replace",
+    "drop",
+    "alter",
+    "create",
+    "truncate",
+    "rename",
+    "grant",
+    "revoke",
+    "call",
+    "exec",
+    "execute",
+    "copy",
+    "vacuum",
+    "attach",
+    "detach",
+    "pragma",
+    "use",
+    "set",
+    "lock",
+    "unlock",
+    "into",  # covers "SELECT ... INTO new_table"
+}
+
+# Matches single- and double-quoted string literals, backtick/bracket
+# identifiers, and line/block comments so keyword scanning doesn't get
+# confused by SQL that merely *mentions* a disallowed word inside a
+# literal (e.g. WHERE comment = 'please insert here').
+_STRIPPABLE_PATTERN = re.compile(
+    r"""
+    '(?:[^'\\]|\\.)*'      # single-quoted string literal
+    | "(?:[^"\\]|\\.)*"    # double-quoted string/identifier
+    | `(?:[^`\\]|\\.)*`    # backtick identifier
+    | --[^\n]*             # line comment
+    | /\*.*?\*/            # block comment
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+_WORD_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _strip_literals_and_comments(sql: str) -> str:
+    return _STRIPPABLE_PATTERN.sub(" ", sql)
+
+
+def _split_statements(sql: str) -> list:
+    """Split on top-level semicolons (literals/comments already stripped)."""
+    statements = [s.strip() for s in sql.split(";")]
+    return [s for s in statements if s]
+
+
+def validate_read_only_sql(sql: str) -> tuple[bool, str | None]:
+    """
+    Check whether the given SQL is a plain, single, read-only statement.
+
+    Args:
+        sql: The raw SQL text supplied to ``query_asset_tool``.
+
+    Returns:
+        A ``(is_valid, error_message)`` tuple. ``error_message`` is ``None``
+        when ``is_valid`` is ``True``.
+    """
+    if not sql or not sql.strip():
+        return False, "SQL query cannot be empty"
+
+    cleaned = _strip_literals_and_comments(sql)
+
+    statements = _split_statements(cleaned)
+    if len(statements) == 0:
+        return False, "SQL query cannot be empty"
+    if len(statements) > 1:
+        return (
+            False,
+            (
+                "Multi-statement SQL is not supported by query_asset_tool; "
+                "please submit a single read-only statement"
+            ),
+        )
+
+    statement = statements[0]
+    words = [w.lower() for w in _WORD_PATTERN.findall(statement)]
+    if not words:
+        return False, "SQL query cannot be empty"
+
+    leading_keyword = words[0]
+    if leading_keyword not in _ALLOWED_LEADING_KEYWORDS:
+        return (
+            False,
+            (
+                "query_asset_tool only supports read-only statements "
+                "(SELECT/WITH/SHOW/DESCRIBE/EXPLAIN/VALUES); "
+                f"'{leading_keyword.upper()}' is not allowed"
+            ),
+        )
+
+    found_disallowed = [w for w in words if w in _DISALLOWED_KEYWORDS]
+    if found_disallowed:
+        return (
+            False,
+            (
+                "query_asset_tool only supports read-only statements; "
+                f"found disallowed keyword(s): {', '.join(sorted(set(found_disallowed)))}"
+            ),
+        )
+
+    return True, None


### PR DESCRIPTION
## Summary
Fixes #226. `query_asset_tool` is documented as read-only ("CRITICAL: Use READ-ONLY queries to retrieve data. Write and modify queries are not supported by this tool."), but `tools/query.py::query_asset()` only checked that `sql` and `connection_qualified_name` were non-empty before building a `QueryRequest` and calling `client.queries.stream(...)`. Any SQL — `INSERT`/`UPDATE`/`DELETE`/DDL, or multiple statements — was passed straight through to the Atlan query service. An operator restricting write tools via `RESTRICTED_TOOLS` (per the README's "Read-Only Access" example) would still have unrestricted SQL execution available, since `query_asset_tool` wasn't even in that list.

## Changes
- **`modelcontextprotocol/utils/sql_validator.py`** (new): a small, dependency-free `validate_read_only_sql(sql)` that:
  - strips string/identifier literals and comments so keyword matching isn't fooled by SQL that merely *mentions* a keyword inside a literal,
  - rejects multi-statement SQL (`;`-separated),
  - only allows statements whose leading keyword is `SELECT`/`WITH`/`SHOW`/`DESCRIBE`/`DESC`/`EXPLAIN`/`VALUES`,
  - rejects write/DDL/session keywords (`INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `GRANT`, `INTO`, ...) anywhere in the statement, so a write hidden inside a CTE (e.g. `WITH t AS (INSERT INTO ... RETURNING *) SELECT * FROM t`) is also caught.
- **`modelcontextprotocol/tools/query.py`**: call the validator before constructing `QueryRequest`; on rejection, return the existing `{success, data, error, query_info}` shape (fails closed, never reaches the Atlan client) rather than raising.
- **`modelcontextprotocol/server.py`**: note the enforcement in the `query_asset_tool` docstring.
- **`modelcontextprotocol/README.md`**: add `query_asset_tool` to the documented tool-restriction list (it was already restrictable via `RESTRICTED_TOOLS`, just undocumented), and note that the tool now rejects non-read-only SQL on its own.
- **`modelcontextprotocol/tests/`** (new): this repo has no test suite yet (tracked separately in #36), so I added a minimal `pytest` setup (wired via `[tool.pytest.ini_options]` in `pyproject.toml`, `pytest` added as a `dev` extra) with:
  - `test_sql_validator.py`: parametrized allow/reject cases for the validator.
  - `test_query.py`: confirms `query_asset()` rejects write/multi-statement SQL *without* calling `get_atlan_client()`, and that a valid `SELECT` still reaches `QueryRequest`/`client.queries.stream()` (mocked, no network/credentials needed).

This is intentionally a conservative keyword-based check rather than a full SQL parser/AST — it's meant to fail closed on anything ambiguous rather than to validate SQL correctness, per the issue's suggested approach.

## Test plan
- [x] `pytest tests/` — 27 passed
- [x] `ruff check` / `ruff format` clean on all new/touched files
- [x] Manually verified against the issue's repro shape (`INSERT`/`UPDATE`/`DELETE`/DDL/multi-statement SQL rejected before `QueryRequest` is built; existing `SELECT` examples from the tool's own docstring still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)