### PR TITLE
feat(skills): add the talk-to-data loop (build-view, assess-gap, update-to-atlan)

### DIFF
--- a/skills/assess-gap/SKILL.md
+++ b/skills/assess-gap/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: assess-gap
+description: >
+  Diagnoses WHY a semantic view is failing its evals and proposes grounded,
+  typed context fixes — the "map" for turning a red eval into a specific,
+  defensible change to the model. Runs after build+deploy+eval in the
+  talk-to-data loop: it reads only the SAFE eval projection (never the
+  golden answers), classifies each failure against a fixed gap taxonomy,
+  and emits one grounded diff per gap that the fix step applies and the
+  update-to-atlan skill persists to Atlan. This is the field-team framework
+  for "how do I read a failing eval and know what context is missing?"
+  Trigger phrases: "assess the gap", "why is my semantic view failing",
+  "diagnose the eval failures", "what context is missing", "improve my
+  semantic view against the evals", "hillclimb the model".
+---
+
+# assess-gap — read the failures, name the missing context
+
+You are the **gap-assessment** step of the eval-driven talk-to-data loop:
+`build → deploy → eval → **assess-gap** → fix → re-eval → update-to-atlan`.
+Your job is NOT to answer the questions. It is to explain, for each failing
+eval case, **what context the model was missing that made the agent generate
+the wrong SQL**, and to propose exactly one grounded fix per gap.
+
+Two non-negotiables define this skill:
+
+1. **You never see the golden answers.** You diagnose only from what the agent
+   *did* (its generated SQL / answer / verdict) versus the model it *had*. The
+   correct answers are firewalled out of your inputs on purpose (see Phase 1).
+   Diagnosing against the oracle is teaching-to-the-test; it produces fixes that
+   pass the eval and fail in production. Refuse to proceed if goldens leak in.
+2. **Every fix is grounded in the model.** Each proposed `expr`/column MUST
+   appear verbatim in the current semantic model. You never invent a table,
+   column, or join. If you cannot ground a fix, you say so — you do not guess.
+
+## Phase 1 — Resolve inputs and prove the firewall
+
+Gather, from the loop's working directory (take these as inputs; never hardcode
+a dataset, run-id, or path):
+
+- **the safe eval projection** — one record per case with
+  `{case_id, question, engine, verdict, cortex_sql | generated_sql, answer}`.
+  It MUST NOT contain any of `golden_result`, `golden_value`, `golden_sql`,
+  `judge_reason`. If any of those keys is present, **STOP** and surface it: the
+  file is not a safe projection and reading it would leak the oracle. (The
+  reference harness enforces this in `read_traces.load_safe()`, which hard-aborts
+  on those sealed keys — cite that mechanism; do not re-implement a weaker one.)
+- **the current model structure** — names only: per table its
+  `dimensions / time_dimensions / facts / existing filters {name, expr} /
+  relationships {left, right, on}`. This is your grounding vocabulary.
+- **the engine** — `cortex` or `genie` (or `databricks`). Do not assume Cortex;
+  the gap classes below are engine-neutral, but the fix vocabulary must match.
+- **the accuracy target** (Y%) and the iteration budget (1–2), for the caller's
+  stop condition.
+
+If there is no eval run yet, hand back to the eval step to produce one first.
+
+## Phase 2 — Read only the failures
+
+Select cases with `verdict ∈ {mismatch, partial, abstain}` **and** no
+answer/deploy error (a compile/deploy failure is a build problem, not a context
+gap — route those back to build/deploy, don't diagnose them here). For each,
+you now have: the question, the SQL the agent generated, and the verdict. That
+triplet — question vs. generated SQL vs. available model — is the entire basis
+for diagnosis.
+
+## Phase 3 — Classify the gap (THE MAP)
+
+For each failing case, match the tell to exactly one gap class. This taxonomy is
+the framework — state the class you chose out loud, so the reasoning is legible
+and teachable, not a black box.
+
+Every persistable fix routes through the `update-to-atlan` skill
+(types: `description`, `glossary_term`, `filter`, `relationship`, `popular_query`).
+A fix whose value lives in the semantic model itself (a metric's calculation, a
+verified query, a time dimension) is **not** a separate Atlan asset — apply it to
+the model and say so; do not force it into a writeback type.
+
+| # | Diagnostic tell (what the generated SQL shows) | Gap class | Fix (typed diff) | Persists to Atlan as |
+|---|---|---|---|---|
+| 1 | Queried a rollup/summary/wrong table, or the wrong grain (e.g. `SUM` over a pre-aggregated table when the question is per-entity) | **Wrong table / grain** | `description` disambiguating the tables (a true grain metric = a calc that stays in the model) | `description` (write-back type) |
+| 2 | Right table, but no `WHERE` (or the wrong one) for the business subset the question names ("open", "active", "S2+", "at-risk") | **Missing subset** | `filter` — a named, reusable predicate | `filter` → `SqlInsightFilter` |
+| 3 | Needed two tables but couldn't join them (picked one, or produced a cross-join / duplicate counts) | **Missing relationship** | `relationship` — the join key | `relationship` → `SqlInsightJoin` |
+| 4 | Abstained / asked for clarification, or grabbed the wrong column for a business term ("well-worked", "AI-ready", "our accounts") | **Vocabulary gap** | `glossary_term` binding the term to the column (synonyms carried in the term description — no structured-synonym attribute in the write path) | `glossary_term` → `AtlasGlossaryTerm` (+ column `meanings` edge) |
+| 5 | Wrong point-in-time or window (used all-time when the question is "right now", or the wrong date column) | **Temporal logic** | a `verified_query`/`time_dimension` in the model; if a governed window exists, a `description` naming it | model-only (no Atlan asset), or a `description` write-back |
+
+Rules for classification:
+- Prefer the table the **question** is really about, not the one the agent
+  wrongly used. The most common failure is class 1 → the fix is often to make
+  the right table/subset expressible (class 2), not to describe the wrong one.
+- One class, one fix per case. If two gaps stack, fix the upstream one first
+  (usually table/grain before subset) and let the re-eval surface the rest.
+- If the tell is genuinely ambiguous (you cannot tell which column a term maps
+  to), the fix type is `description` and the `diagnosis` states the ambiguity as
+  a question for a human — never invent the mapping.
+
+## Phase 4 — Propose grounded fixes
+
+Emit one typed diff per gap, each of this shape:
+
+```
+{ case_id, gap_class,               // the # from the map, named
+  diagnosis,                        // one sentence: what was missing, from SQL vs model
+  type,                             // filter | relationship | description | glossary_term | popular_query | model-only
+  target_table, name,
+  expr, columns_used[],             // MUST be verbatim from the model structure
+  description }                     // when-to-use text a downstream consumer will read
+```
+
+Hard grounding check before you output: for every `expr`/`columns_used`, confirm
+the token appears in the Phase-1 model structure. Drop (don't fudge) any fix you
+can't ground, and note it as an ungrounded gap for a human.
+
+## Phase 5 — Hand off
+
+- To the **fix** step: apply the diffs to the model and redeploy (patch the model
+  for the in-session result; do not wait on a rebuild-from-Atlan — gold-sync lag
+  and governance approval are off the critical path here). Then re-eval the
+  affected cases only, against the SAME fresh goldens, and report before→after.
+- To the **`update-to-atlan`** skill (the loop's close for *persistable* fixes):
+  for each grounded fix whose type is a write-back type (`description` /
+  `glossary_term` / `filter` / `relationship` / `popular_query`), hand it to
+  `update-to-atlan`, which presents the exact diff + target and performs the write.
+  - **The write is gated on the human's approval.** If the user's prompt authorized
+    persisting ("write the fix back to Atlan"), proceed. Otherwise present the fix
+    (via `update-to-atlan`, or plainly if non-interactive) and **stop for approval**
+    — do NOT treat a bypass/non-interactive permission mode as standing approval for
+    a write to production Atlan. Reaching the gate is the goal; crossing it needs a human.
+  - **model-only fixes** (a metric's calculation, a verified query, a time
+    dimension with no governed Atlan window) are applied to the model and reported —
+    there is nothing to dispatch to `update-to-atlan`.
+  - Do NOT write the entity inline with ad-hoc MCP/Bash — the `update-to-atlan` skill owns the write.
+- Loop: if the target Y% isn't met and iterations remain, feed the new failures
+  back to Phase 2. Stop at Y% or the iteration budget, and report which gaps were
+  filled (and from which source) and which remain.
+
+## Style rules
+
+- State the gap class for every failure — the value of this skill is the legible
+  map, not just the patch. A silent fix teaches the field team nothing.
+- Never read goldens; never invent names; never teach to the test. If any of the
+  three is at risk, STOP and surface it rather than produce a fix that looks good
+  on the eval and fails in production.
+- Report honestly: "1 of 5 fixed, 3 need a human" beats a fabricated clean climb.
+- Never log secrets or credential values.
+
+## Before you end this skill — presentation gate (read this last)
+
+Do not end by silently dropping a grounded fix. Before your closing summary, for
+each grounded, persistable fix, **present it** — surface the exact typed diff +
+its Atlan target (dispatching `update-to-atlan` is the cleanest way to present, since
+it shows the diff and holds at its approval gate). Then:
+
+1. If the user authorized persisting, let the write proceed and report the
+   read-back (`status` / `verbatim_ok`).
+2. If not (or the run is non-interactive), present the fix and **stop for the
+   human's approval** — do NOT write to production Atlan on your own authority.
+3. Apply **model-only** fixes to the model and report them; there is nothing to persist.
+
+A fix you found but neither presented nor applied is the failure mode to avoid —
+name every gap and its fix. If there is genuinely no grounded fix, say so.

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -26,10 +26,10 @@ or eval here.
 ## Phase 1 — Resolve inputs
 
 - `tables[]` — the Atlan **`qualifiedName`** of each table, **including the
-  connection prefix** — e.g.
-  `default/snowflake/<connectionId>/GTM_OPERATIONS_PROD/MARTS/DIM_ACCOUNTS`, NOT the
-  short `DB/SCHEMA/TABLE` form (the short form fails with a 404). **Required.** If
-  missing or ambiguous, ask — never invent a table list.
+  connection prefix** — i.e.
+  `default/snowflake/<connectionId>/<DATABASE>/<SCHEMA>/<TABLE>`, NOT the
+  short `<DATABASE>/<SCHEMA>/<TABLE>` form (the short form fails with a 404).
+  **Required.** If missing or ambiguous, ask — never invent a table list.
   - **Close the join set.** A relationship renders only when **both** ends of a
     join are in `tables[]`. Picking tables by importance/density usually drops the
     reference/dimension tables your facts join to, and you get a joinless model with

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: build-view
+description: >
+  Builds a Snowflake Cortex / Databricks Genie semantic model for a stated
+  use-case from a given table list, using Atlan-governed context (descriptions,
+  business rules, joins, glossary), and returns it. It does NOT author semantic
+  meaning with the LLM — every element of the model comes from a concrete Atlan
+  artifact. It does NOT deploy or evaluate: those are separate steps the caller
+  drives if needed. Trigger phrases: "build a semantic view", "build a view for
+  <use-case>", "build the semantic model from these tables".
+---
+
+# build-view — governed semantic-model build
+
+You turn `{use_case, tables[], engine}` into a governed semantic model whose
+every dimension, metric, filter, relationship, and instruction traces to an
+Atlan artifact. The LLM's role is discovery/selection only — it never writes the
+semantic content. That grounding is the value: the model is as good as the
+governed context.
+
+Scope is deliberately narrow: **this skill builds and returns the model.**
+Deploying it, evaluating it, and diagnosing gaps are separate concerns — the
+caller invokes them (or asks for them in the prompt) when needed. Do not deploy
+or eval here.
+
+## Phase 1 — Resolve inputs
+
+- `tables[]` — fully-qualified table identifiers to model. **Required.** If
+  missing or ambiguous, ask — never invent a table list.
+- `engine` — `cortex` | `genie` | `databricks`. Ask if not implied.
+- `use_case` — labels intent; carried into naming/description.
+
+## Phase 2 — Build via the companion script
+
+Run the bundled companion — **`${CLAUDE_PLUGIN_ROOT}/skills/build-view/build_model.py`** —
+never improvise the HTTP call. The script owns the endpoint, auth header, timeout,
+and error handling so the build is deterministic:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/build-view/build_model.py \
+  --tables @tables.json --engine <cortex|genie|databricks> --name <use_case> --out model.yaml
+```
+
+It POSTs `{tables, engine, name}` to the governed `/semantic-model/build`
+(store-nothing) endpoint and writes the returned model YAML to `--out`. Endpoint
+resolution: `--endpoint` › `$ATLAN_BUILD_ENDPOINT` (override, e.g. the local mock)
+› the script's baked-in hosted default. Auth is automatic: it sends
+`Authorization: Bearer $ATLAN_API_KEY` when set (the hosted endpoint requires it;
+the mock ignores it). Do **NOT** use any superseded "generate" path.
+
+The build reads columns, descriptions, business rules (custom instructions),
+joins, and glossary from Atlan's catalog. No LLM authoring happens.
+
+**It blocks (real builds take 4–5 min); the script's default timeout is 400s.** If
+you run it from a shell tool, raise that tool's timeout to match — do not accept a
+120s default, and do not background it (a backgrounded call loses the YAML).
+
+**On failure the script exits non-zero with the HTTP code (never the credential)
+— STOP and surface it.** Do not hand-author a model to keep going. `validation:
+skipped` is NOT a failure (no engine was reachable to compile-check) — the script
+carries the model forward and says so.
+
+## Phase 3 — Return the model
+
+Hand back the `--out` path with a one-line summary (engine + table count from the
+script's output). Nothing else — no deploy, no gap analysis.
+
+## Style rules
+
+- Zero LLM authoring of semantic meaning. Every element maps to an Atlan
+  artifact; if Atlan can't supply something, leave it out — do not invent it.
+- Prefer the governed build path; if a tool/endpoint is unavailable, STOP and
+  say so — don't substitute a different builder silently.
+- Never log secrets or credential values.

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -42,18 +42,24 @@ or eval here.
   interchangeable, and a plausible-looking file for the wrong engine will not deploy:
   - `cortex` — Snowflake Cortex Analyst semantic model (`snowflake` is accepted too).
   - `genie` — the Databricks Genie space config. It carries only the cross-table
-    extras (joins, verified answers, filters, instructions, synonyms) and defers table
-    and column identity to the deploy, so **a small or near-empty config is normal**,
-    not a failed build — on a tenant with no observed joins and no analyst questions
-    every section is legitimately empty. The render always marks it `_partial` and the
-    endpoint returns a warning saying so; report that warning, do not treat it as an
-    error.
-  - `databricks` — the Databricks metric view. A separate render, not part of `genie`.
-    **Build order does not matter** — the Genie config's deploy-time fields (space
-    title, table identifiers, warehouse, metric-view name) are filled by the deploy,
-    not by the build, so building the metric view first does not change the Genie
-    output. A Genie space does need a metric view to point at, so build both; either
-    order.
+    extras (joins, verified answers, filters, instructions, synonyms); table and
+    column identity are filled at deploy. So **a small or near-empty config is
+    normal**, not a failed build — on a tenant with no observed joins and no analyst
+    questions every section is legitimately empty. The render always stamps
+    `_partial: true` and the endpoint returns a warning saying so. Report that
+    warning; it is not an error, and it does **not** mean anything is missing from
+    the build — the marker is unconditional.
+  - `databricks` — the Databricks metric view, rendered as a deployable bundle
+    (`metric_view.yaml` plus the `metric_view.deploy.yaml` a deploy actually reads).
+    **A Genie space needs this deployed first.** The Genie config's `metric_view_fqn`
+    is supplied at deploy time from the catalog / schema / view of a metric view that
+    already exists in Databricks, so end to end the order is: build the metric view →
+    deploy it → build the Genie config → deploy the space. If the target is Genie,
+    ask for **both** engines.
+
+  The two BUILDS are independent — asking for `databricks` first does not change the
+  `genie` output — but the DEPLOYS are ordered, because the space can only point at a
+  metric view that already exists.
   - `dbt` — dbt semantic model; validates offline against `dbt-semantic-interfaces`,
     the suite dbt-core and MetricFlow run.
 - `use_case` — labels intent; carried into naming/description.

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -75,6 +75,12 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/build-view/build_model.py \
   --tables @tables.json --engine <cortex|databricks|genie|dbt> --name <use_case> --out model.yaml
 ```
 
+**A Genie target is two runs, not one.** When the stated target is a Genie space,
+run the script twice with the same `tables[]` — once `--engine databricks` and once
+`--engine genie` — and hand back both artifacts. One call returns one engine's
+artifact, and a Genie space needs the metric view as well (see Phase 1). Do not
+substitute one for the other, and do not ask the caller to choose between them.
+
 It POSTs `{tables, engine, name}` to the governed `/semantic-model/build`
 (store-nothing) endpoint and writes the returned model YAML to `--out`. Endpoint
 resolution: `--endpoint` › `$ATLAN_BUILD_ENDPOINT`. **One of the two is required** —
@@ -113,6 +119,11 @@ status that is fatal.
 
 Hand back the `--out` path with a one-line summary (engine + table count from the
 script's output). Nothing else — no deploy, no gap analysis.
+
+For a Genie target, hand back **both** paths — the metric view and the Genie config —
+and state the deploy order: the metric view is deployed first, then the space, because
+the space's `metric_view_fqn` is supplied at deploy time from a metric view that
+already exists.
 
 ## Style rules
 

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -41,12 +41,12 @@ or eval here.
 - `engine` — which form to return. Ask if not implied; they are not
   interchangeable, and a plausible-looking file for the wrong engine will not deploy:
   - `cortex` — Snowflake Cortex Analyst semantic model (`snowflake` is accepted too).
-  - `databricks` — the Databricks metric view a deploy reads.
-  - `genie` — the Databricks Genie semantic model. **Not the same as `databricks`** —
-    same platform, different artifact.
+  - `genie` — the Databricks Genie config.
+  - `databricks` — the Databricks metric view. **Ask for this separately** — it is a
+    different artifact, not part of the `genie` render. The Genie config only
+    *references* a metric view by name, so a Genie space needs both.
   - `dbt` — dbt semantic model; validates offline against `dbt-semantic-interfaces`,
     the suite dbt-core and MetricFlow run.
-  - `atlan` — Atlan's own canonical model (the endpoint's default).
 - `use_case` — labels intent; carried into naming/description.
 
 ## Phase 2 — Build via the companion script
@@ -57,7 +57,7 @@ and error handling so the build is deterministic:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/build-view/build_model.py \
-  --tables @tables.json --engine <atlan|cortex|databricks|genie|dbt> --name <use_case> --out model.yaml
+  --tables @tables.json --engine <cortex|databricks|genie|dbt> --name <use_case> --out model.yaml
 ```
 
 It POSTs `{tables, engine, name}` to the governed `/semantic-model/build`
@@ -71,11 +71,10 @@ the mock ignores it). Do **NOT** use any superseded "generate" path.
 The build reads columns, descriptions, business rules (custom instructions),
 joins, and glossary from Atlan's catalog. No LLM authoring happens.
 
-**It blocks, and build time scales with the table count** — roughly 5 min for 5
-tables, 9 min for 14, and the endpoint accepts up to 50. The script's default timeout
-is 1200s. If you run it from a shell tool, raise that tool's timeout to match the
-table count — do not accept a 120s default, and do not background it (a backgrounded
-call loses the YAML).
+**It blocks, and build time grows with the table count.** The script's default
+timeout is 1200s. If you run it from a shell tool, raise that tool's timeout to match
+— do not accept a 120s default, and do not background it (a backgrounded call loses
+the YAML).
 
 **Read the exit as one of three outcomes.** Do not hand-author a model in any of
 them.

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -41,10 +41,19 @@ or eval here.
 - `engine` — which form to return. Ask if not implied; they are not
   interchangeable, and a plausible-looking file for the wrong engine will not deploy:
   - `cortex` — Snowflake Cortex Analyst semantic model (`snowflake` is accepted too).
-  - `genie` — the Databricks Genie config.
-  - `databricks` — the Databricks metric view. **Ask for this separately** — it is a
-    different artifact, not part of the `genie` render. The Genie config only
-    *references* a metric view by name, so a Genie space needs both.
+  - `genie` — the Databricks Genie space config. It carries only the cross-table
+    extras (joins, verified answers, filters, instructions, synonyms) and defers table
+    and column identity to the deploy, so **a small or near-empty config is normal**,
+    not a failed build — on a tenant with no observed joins and no analyst questions
+    every section is legitimately empty. The render always marks it `_partial` and the
+    endpoint returns a warning saying so; report that warning, do not treat it as an
+    error.
+  - `databricks` — the Databricks metric view. A separate render, not part of `genie`.
+    **Build order does not matter** — the Genie config's deploy-time fields (space
+    title, table identifiers, warehouse, metric-view name) are filled by the deploy,
+    not by the build, so building the metric view first does not change the Genie
+    output. A Genie space does need a metric view to point at, so build both; either
+    order.
   - `dbt` — dbt semantic model; validates offline against `dbt-semantic-interfaces`,
     the suite dbt-core and MetricFlow run.
 - `use_case` — labels intent; carried into naming/description.

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -25,8 +25,16 @@ or eval here.
 
 ## Phase 1 — Resolve inputs
 
-- `tables[]` — fully-qualified table identifiers to model. **Required.** If
+- `tables[]` — the Atlan **`qualifiedName`** of each table, **including the
+  connection prefix** — e.g.
+  `default/snowflake/<connectionId>/GTM_OPERATIONS_PROD/MARTS/DIM_ACCOUNTS`, NOT the
+  short `DB/SCHEMA/TABLE` form (the short form fails with a 404). **Required.** If
   missing or ambiguous, ask — never invent a table list.
+  - **Close the join set.** A relationship renders only when **both** ends of a
+    join are in `tables[]`. Picking tables by importance/density usually drops the
+    reference/dimension tables your facts join to, and you get a joinless model with
+    nothing in the output signalling anything is missing. Include those referenced
+    dimension tables. (Filters need only their own table; relationships need both ends.)
 - `engine` — `cortex` | `genie` | `databricks`. Ask if not implied.
 - `use_case` — labels intent; carried into naming/description.
 

--- a/skills/build-view/SKILL.md
+++ b/skills/build-view/SKILL.md
@@ -35,7 +35,18 @@ or eval here.
     reference/dimension tables your facts join to, and you get a joinless model with
     nothing in the output signalling anything is missing. Include those referenced
     dimension tables. (Filters need only their own table; relationships need both ends.)
-- `engine` — `cortex` | `genie` | `databricks`. Ask if not implied.
+  - **At most 50 tables per build.** The endpoint caps the list in its request schema,
+    so 51+ is refused with a 422 before any build starts. Split the list, or narrow it
+    to the use case.
+- `engine` — which form to return. Ask if not implied; they are not
+  interchangeable, and a plausible-looking file for the wrong engine will not deploy:
+  - `cortex` — Snowflake Cortex Analyst semantic model (`snowflake` is accepted too).
+  - `databricks` — the Databricks metric view a deploy reads.
+  - `genie` — the Databricks Genie semantic model. **Not the same as `databricks`** —
+    same platform, different artifact.
+  - `dbt` — dbt semantic model; validates offline against `dbt-semantic-interfaces`,
+    the suite dbt-core and MetricFlow run.
+  - `atlan` — Atlan's own canonical model (the endpoint's default).
 - `use_case` — labels intent; carried into naming/description.
 
 ## Phase 2 — Build via the companion script
@@ -46,27 +57,43 @@ and error handling so the build is deterministic:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/build-view/build_model.py \
-  --tables @tables.json --engine <cortex|genie|databricks> --name <use_case> --out model.yaml
+  --tables @tables.json --engine <atlan|cortex|databricks|genie|dbt> --name <use_case> --out model.yaml
 ```
 
 It POSTs `{tables, engine, name}` to the governed `/semantic-model/build`
 (store-nothing) endpoint and writes the returned model YAML to `--out`. Endpoint
-resolution: `--endpoint` › `$ATLAN_BUILD_ENDPOINT` (override, e.g. the local mock)
-› the script's baked-in hosted default. Auth is automatic: it sends
+resolution: `--endpoint` › `$ATLAN_BUILD_ENDPOINT`. **One of the two is required** —
+there is no baked-in default, and the script exits telling you so. Auth is automatic:
+it sends
 `Authorization: Bearer $ATLAN_API_KEY` when set (the hosted endpoint requires it;
 the mock ignores it). Do **NOT** use any superseded "generate" path.
 
 The build reads columns, descriptions, business rules (custom instructions),
 joins, and glossary from Atlan's catalog. No LLM authoring happens.
 
-**It blocks (real builds take 4–5 min); the script's default timeout is 400s.** If
-you run it from a shell tool, raise that tool's timeout to match — do not accept a
-120s default, and do not background it (a backgrounded call loses the YAML).
+**It blocks, and build time scales with the table count** — roughly 5 min for 5
+tables, 9 min for 14, and the endpoint accepts up to 50. The script's default timeout
+is 1200s. If you run it from a shell tool, raise that tool's timeout to match the
+table count — do not accept a 120s default, and do not background it (a backgrounded
+call loses the YAML).
 
-**On failure the script exits non-zero with the HTTP code (never the credential)
-— STOP and surface it.** Do not hand-author a model to keep going. `validation:
-skipped` is NOT a failure (no engine was reachable to compile-check) — the script
-carries the model forward and says so.
+**Read the exit as one of three outcomes.** Do not hand-author a model in any of
+them.
+
+- **No model** — the script exits non-zero and no file is written (bad engine, no
+  tables, every table failed, assembly failed). STOP and surface its message.
+- **PARTIAL** — exits non-zero, *and the model is on disk*: some tables did not model
+  and the script names each one with its reason. The model covers the rest and is
+  deployable for those tables. Surface the failed tables and let the caller decide
+  whether to proceed or fix the list — do not silently treat it as clean.
+- **REJECTED** — exits non-zero with the model on disk, but the target engine's own
+  validator refused the file (`validation: invalid`). This is **not** a partial build:
+  the model is whole and **will not deploy**. Never present it as usable. Surface the
+  engine's error verbatim.
+
+`validation: skipped` is NOT a failure (no engine was reachable to compile-check) —
+the script carries the model forward and says so. `invalid` is the only validation
+status that is fatal.
 
 ## Phase 3 — Return the model
 

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -35,7 +35,7 @@ DEFAULT_ENDPOINT = ""
 
 # The endpoint caps `tables` at 50 in its request schema (Pydantic `max_length`), so a
 # larger list is refused with a 422 before the build starts. Mirrored here only to name
-# the limit in errors and help text — the endpoint remains the authority.
+# the limit in the 422 error — the endpoint remains the authority.
 MAX_TABLES = 50
 
 UA = (

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""build-view companion — deterministic call to the governed semantic-model build.
+
+Stdlib only. POSTs {tables, engine, name} to the governed build endpoint, saves the
+returned model YAML, and prints a one-line summary. This is the script the
+build-view skill runs, so the endpoint call, auth, timeout, and error handling are
+identical every time (not improvised by the model).
+
+Endpoint resolution (first that is set wins):
+  --endpoint <url>                     explicit
+  $ATLAN_BUILD_ENDPOINT                override (e.g. the local mock)
+  DEFAULT_ENDPOINT constant below      the hosted governed endpoint (if baked)
+
+Auth: sends `Authorization: Bearer $ATLAN_API_KEY` when that env var is set (the
+hosted endpoint requires it; the local mock ignores it). Never prints the value.
+
+Usage:
+  build_model.py --tables @tables.json --engine cortex --name gtm --out model.yaml
+  build_model.py --tables A,B,C --engine cortex --name gtm --out model.yaml
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.request
+import urllib.error
+
+# The governed build endpoint is your Atlan tenant's store-nothing
+# `/semantic-model/build` API. Set it via $ATLAN_BUILD_ENDPOINT or --endpoint;
+# auth is Bearer $ATLAN_API_KEY.
+DEFAULT_ENDPOINT = ""
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+
+def resolve_endpoint(cli):
+    return (
+        cli
+        or os.environ.get("ATLAN_BUILD_ENDPOINT")
+        or DEFAULT_ENDPOINT
+        or sys.exit(
+            "ERROR: no build endpoint — pass --endpoint, set $ATLAN_BUILD_ENDPOINT, "
+            "point --endpoint at your tenant's governed /semantic-model/build endpoint."
+        )
+    )
+
+
+def load_tables(val):
+    if val.startswith("@"):
+        data = json.load(open(val[1:]))
+        return data if isinstance(data, list) else data.get("tables", [])
+    return [t.strip() for t in val.split(",") if t.strip()]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--tables",
+        required=True,
+        help="comma list or @file.json (list or {tables:[...]})",
+    )
+    p.add_argument(
+        "--engine", default="cortex", choices=["cortex", "genie", "databricks"]
+    )
+    p.add_argument("--name", required=True)
+    p.add_argument("--out", required=True, help="path to write the returned model YAML")
+    p.add_argument("--endpoint", default=None)
+    p.add_argument(
+        "--timeout", type=int, default=400, help="seconds; real build takes 4-5 min"
+    )
+    a = p.parse_args()
+
+    url = resolve_endpoint(a.endpoint)
+    tables = load_tables(a.tables)
+    if not tables:
+        sys.exit("ERROR: no tables resolved from --tables")
+
+    body = json.dumps({"tables": tables, "engine": a.engine, "name": a.name}).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header(
+        "User-Agent", UA
+    )  # Atlan is behind Cloudflare (1010-blocks default urllib UA)
+    key = os.environ.get("ATLAN_API_KEY")
+    if key:
+        req.add_header("Authorization", "Bearer " + key)  # value never printed
+
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=a.timeout) as r:
+            resp = json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        sys.exit(f"ERROR: build endpoint returned HTTP {e.code} (body withheld)")
+    except Exception as e:
+        sys.exit(f"ERROR: build call failed: {type(e).__name__}: {e}")
+
+    if not resp.get("success") or not resp.get("content"):
+        sys.exit(
+            f"ERROR: build did not return a model (message: {resp.get('message','?')})"
+        )
+
+    open(a.out, "w").write(resp["content"])
+    val = resp.get("validation", {})
+    print(
+        f"built {a.engine} model → {a.out}  "
+        f"tables_modelled={len(resp.get('tables_modelled', []))}  "
+        f"dropped={len(resp.get('dropped', []))}  "
+        f"validation={val.get('status', '?') if isinstance(val, dict) else val}"
+    )
+    if isinstance(val, dict) and val.get("status") == "skipped":
+        print(
+            "  note: validation skipped (no engine reachable to compile-check) — carry forward"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -6,18 +6,18 @@ returned model YAML, and prints a one-line summary. This is the script the
 build-view skill runs, so the endpoint call, auth, timeout, and error handling are
 identical every time (not improvised by the model).
 
-Endpoint resolution (first that is set wins):
+Endpoint resolution (first that is set wins). One of the two is REQUIRED — there is
+no baked-in default, and the script exits saying so:
   --endpoint <url>                     explicit
-  $ATLAN_BUILD_ENDPOINT                override (e.g. the local mock)
-  DEFAULT_ENDPOINT constant below      the hosted governed endpoint (if baked)
+  $ATLAN_BUILD_ENDPOINT                your tenant's /semantic-model/build
 
 Auth: sends `Authorization: Bearer $ATLAN_API_KEY` when that env var is set (the
 hosted endpoint requires it; the local mock ignores it). Never prints the value.
 
 Usage:
-  build_model.py --tables @tables.json --engine cortex --name gtm --out model.yaml
+  build_model.py --tables @tables.json --engine cortex --name <use_case> --out model.yaml
   # --tables entries are Atlan qualifiedNames WITH the connection prefix (not DB/SCHEMA/TABLE):
-  build_model.py --tables default/snowflake/<conn>/<DATABASE>/<SCHEMA>/<TABLE> --engine cortex --name gtm --out model.yaml
+  build_model.py --tables default/snowflake/<conn>/<DATABASE>/<SCHEMA>/<TABLE> --engine cortex --name <use_case> --out model.yaml
 """
 
 import argparse

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -33,6 +33,11 @@ import urllib.error
 # auth is Bearer $ATLAN_API_KEY.
 DEFAULT_ENDPOINT = ""
 
+# The endpoint caps `tables` at 50 in its request schema (Pydantic `max_length`), so a
+# larger list is refused with a 422 before the build starts. Mirrored here only to name
+# the limit in errors and help text — the endpoint remains the authority.
+MAX_TABLES = 50
+
 UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
@@ -66,13 +71,25 @@ def main():
         help="comma list or @file.json (list or {tables:[...]})",
     )
     p.add_argument(
-        "--engine", default="cortex", choices=["cortex", "genie", "databricks"]
+        "--engine",
+        default="cortex",
+        # The five distinct engines the build endpoint renders. `databricks` and `genie`
+        # are NOT the same output: `databricks` is the metric view a deploy reads, `genie`
+        # is the Genie semantic model. `atlan` is the endpoint's own default (its canonical
+        # model). `snowflake` is accepted server-side as an alias for `cortex`.
+        choices=["atlan", "cortex", "databricks", "genie", "dbt"],
     )
     p.add_argument("--name", required=True)
     p.add_argument("--out", required=True, help="path to write the returned model YAML")
     p.add_argument("--endpoint", default=None)
     p.add_argument(
-        "--timeout", type=int, default=400, help="seconds; real build takes 4-5 min"
+        "--timeout",
+        type=int,
+        default=1200,
+        help=(
+            "seconds. Build time scales with the table count: ~5 min for 5 tables, "
+            "~9 min for 14, and the endpoint accepts up to %d." % MAX_TABLES
+        ),
     )
     a = p.parse_args()
 
@@ -96,16 +113,31 @@ def main():
         with urllib.request.urlopen(req, context=ctx, timeout=a.timeout) as r:
             resp = json.loads(r.read().decode())
     except urllib.error.HTTPError as e:
+        if e.code == 422:
+            # The endpoint caps `tables` at MAX_TABLES in its request schema, so this
+            # fails Pydantic validation before any build starts. Naming the cap here
+            # because a bare 422 gives the caller no way to learn the limit exists.
+            sys.exit(
+                f"ERROR: build endpoint rejected the request (HTTP 422). "
+                f"You passed {len(tables)} tables and the endpoint accepts at most "
+                f"{MAX_TABLES}. Split the list, or narrow it to the use case."
+            )
         sys.exit(f"ERROR: build endpoint returned HTTP {e.code} (body withheld)")
     except Exception as e:
         sys.exit(f"ERROR: build call failed: {type(e).__name__}: {e}")
 
-    if not resp.get("success") or not resp.get("content"):
-        sys.exit(
-            f"ERROR: build did not return a model (message: {resp.get('message','?')})"
-        )
+    # Gate on `content`, never on `success`. Of the endpoint's return paths only the
+    # final one populates `content`, so empty content is the one true "no model" signal;
+    # every other path (unsupported engine, no tables, all tables failed, assembly
+    # failed) returns empty content and puts the actionable text in `message`.
+    content = resp.get("content") or ""
+    if not content:
+        sys.exit(f"ERROR: build returned no model: {resp.get('message', '?')}")
 
-    open(a.out, "w").write(resp["content"])
+    # A model came back. Write it before reporting, so a partial or rejected model is
+    # still on disk to inspect — the previous behaviour discarded a usable 16-table
+    # model when one table of seventeen failed.
+    open(a.out, "w").write(content)
     val = resp.get("validation", {})
 
     # `dropped` is a structured list (per-entry section / entry_name / reason).
@@ -138,6 +170,40 @@ def main():
         print(
             "  note: validation skipped (no engine reachable to compile-check) — carry forward"
         )
+
+    # `success` is False for two different reasons and they are not interchangeable:
+    # tables that failed to model (the model is PARTIAL but deployable for what it
+    # covers) and the engine's own validator refusing the file (the model is COMPLETE
+    # but will not deploy). Report them separately; `invalid` is the only validation
+    # status the endpoint treats as fatal.
+    failed = resp.get("tables_failed") or []
+    rejected = isinstance(val, dict) and val.get("status") == "invalid"
+
+    for w in resp.get("warnings") or []:
+        print(f"  warning: {w}")
+
+    if failed:
+        print(
+            f"  PARTIAL: {len(failed)} of {len(tables)} tables did not model. "
+            f"The model on disk covers the rest."
+        )
+        for f in failed:
+            if isinstance(f, dict):
+                print(f"    - {f.get('qualified_name', '?')}: {f.get('reason', '?')}")
+            else:
+                print(f"    - {f}")
+
+    if rejected:
+        # Not a partial build. The file is whole and the target engine refused it, so
+        # deploying it will fail. The endpoint puts the engine's own error in `message`.
+        print(f"  REJECTED by {resp.get('engine', a.engine)}: will not deploy as-is.")
+
+    if resp.get("message"):
+        print(f"  {resp['message']}")
+
+    if failed or rejected:
+        # Non-zero so this never reads as a clean build, while the model stays on disk.
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -73,11 +73,10 @@ def main():
     p.add_argument(
         "--engine",
         default="cortex",
-        # The five distinct engines the build endpoint renders. `databricks` and `genie`
-        # are NOT the same output: `databricks` is the metric view a deploy reads, `genie`
-        # is the Genie semantic model. `atlan` is the endpoint's own default (its canonical
-        # model). `snowflake` is accepted server-side as an alias for `cortex`.
-        choices=["atlan", "cortex", "databricks", "genie", "dbt"],
+        # Separate renders, not spellings of each other: `genie` emits the Genie
+        # config, `databricks` emits the metric view that config points at.
+        # `snowflake` is accepted server-side as an alias for `cortex`.
+        choices=["cortex", "databricks", "genie", "dbt"],
     )
     p.add_argument("--name", required=True)
     p.add_argument("--out", required=True, help="path to write the returned model YAML")
@@ -86,10 +85,7 @@ def main():
         "--timeout",
         type=int,
         default=1200,
-        help=(
-            "seconds. Build time scales with the table count: ~5 min for 5 tables, "
-            "~9 min for 14, and the endpoint accepts up to %d." % MAX_TABLES
-        ),
+        help="seconds; build time grows with the table count",
     )
     a = p.parse_args()
 

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -16,7 +16,8 @@ hosted endpoint requires it; the local mock ignores it). Never prints the value.
 
 Usage:
   build_model.py --tables @tables.json --engine cortex --name gtm --out model.yaml
-  build_model.py --tables A,B,C --engine cortex --name gtm --out model.yaml
+  # --tables entries are Atlan qualifiedNames WITH the connection prefix (not DB/SCHEMA/TABLE):
+  build_model.py --tables default/snowflake/<conn>/DB/SCHEMA/DIM_ACCOUNTS --engine cortex --name gtm --out model.yaml
 """
 
 import argparse
@@ -106,11 +107,32 @@ def main():
 
     open(a.out, "w").write(resp["content"])
     val = resp.get("validation", {})
+
+    # `dropped` is a structured list (per-entry section / entry_name / reason).
+    # build-view ends at the handoff, so the caller won't come back for a diagnosis
+    # pass — the reasons are what they need to act (fix the source SQL or accept the
+    # gap). Print a per-section count and write the full list next to --out so
+    # nothing is lost while the summary stays short.
+    dropped = resp.get("dropped", []) or []
+    counts = {}
+    for d in dropped:
+        sec = (d.get("section") or "?") if isinstance(d, dict) else "?"
+        counts[sec] = counts.get(sec, 0) + 1
+    dropped_by_section = (
+        ", ".join(f"{n} {s}" for s, n in sorted(counts.items())) or "none"
+    )
+    if dropped:
+        with open(a.out + ".dropped.json", "w") as f:
+            json.dump(dropped, f, indent=2)
+
     print(
         f"built {a.engine} model → {a.out}  "
         f"tables_modelled={len(resp.get('tables_modelled', []))}  "
-        f"dropped={len(resp.get('dropped', []))}  "
         f"validation={val.get('status', '?') if isinstance(val, dict) else val}"
+    )
+    print(
+        f"  dropped ({len(dropped)}): {dropped_by_section}"
+        + (f"  · full list → {a.out}.dropped.json" if dropped else "")
     )
     if isinstance(val, dict) and val.get("status") == "skipped":
         print(

--- a/skills/build-view/build_model.py
+++ b/skills/build-view/build_model.py
@@ -17,7 +17,7 @@ hosted endpoint requires it; the local mock ignores it). Never prints the value.
 Usage:
   build_model.py --tables @tables.json --engine cortex --name gtm --out model.yaml
   # --tables entries are Atlan qualifiedNames WITH the connection prefix (not DB/SCHEMA/TABLE):
-  build_model.py --tables default/snowflake/<conn>/DB/SCHEMA/DIM_ACCOUNTS --engine cortex --name gtm --out model.yaml
+  build_model.py --tables default/snowflake/<conn>/<DATABASE>/<SCHEMA>/<TABLE> --engine cortex --name gtm --out model.yaml
 """
 
 import argparse

--- a/skills/update-to-atlan/SKILL.md
+++ b/skills/update-to-atlan/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: update-to-atlan
+description: >
+  Persists a proven context fix back to Atlan so it's reused by every future
+  build, consumer, and engine — closing the loop from "fix that helped the eval"
+  to "governed context in the system of record". Given ONE typed context diff
+  (filter / relationship / description / glossary_term / popular_query), it routes
+  to the correct Atlan write tool, gates on explicit human approval (the write
+  tools execute immediately — there is no propose mode), writes, and verifies by
+  reading the entity back. ALWAYS use this skill for ANY intent to persist, push,
+  write, or save context BACK to Atlan — never improvise that write inline with
+  ad-hoc MCP/Bash calls. Trigger phrases: "persist this fix to Atlan", "persist
+  this filter/relationship/term context fix back to Atlan", "push this back to
+  Atlan", "push this filter/relationship/term back to Atlan", "write the context
+  fix back", "write the fix back to Atlan", "update the context in Atlan", "save
+  this fix to Atlan". Fires even when no concrete diff is in context yet — in
+  that case it ASKS the user for the typed diff rather than declining.
+---
+
+# update-to-atlan — the write-back hand
+
+Turn one proven context fix (from assess-gap, or supplied) into durable governed
+context in Atlan — the plugin's value: a one-off patch becomes reusable context.
+
+## Phase 1 — Map the fix to a write, then call the script
+
+On any intent to persist a fix **back to Atlan**, this skill owns it. Take the
+**one typed diff** (use assess-gap's output verbatim; if none is in context, ask
+for it — never invent one). Map it to a `--type` and run the bundled script:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/update-to-atlan/atlan_writeback.py write --type <T> --payload @<file>
+```
+
+| Fix | `--type` | Atlan asset | payload |
+|---|---|---|---|
+| description | `description` | asset `userDescription` (dbt `description` untouched) | `{asset_qn, user_description}` |
+| glossary term | `glossary_term` | `AtlasGlossaryTerm` (+ optional column edge) | `{name, glossary_qn\|glossary_guid, [description], [assign_column_qn]}` |
+| filter | `filter` | `SqlInsightFilter` | `{dataset_qn, column_qn, predicate_sql, name, when_to_use}` |
+| relationship | `relationship` | `SqlInsightJoin` | `{source_dataset_qn, joined_dataset_qn, join_type, cardinality, name, column_pairs:[{source_column_qn, joined_column_qn}]}` |
+| popular query | `popular_query` | `SqlInsightBusinessQuestion` | `{dataset_qn, question, sql, name}` |
+
+The script owns everything operational — auth (`ATLAN_*` env), the Cloudflare
+User-Agent, guid resolution, the right endpoint per type, and read-back — and it
+**raises on anything wrong** (missing env, HTTP error), so don't pre-check those;
+surface its error if it fails. Notes: a **metric** is not a write type — persist
+its definition as a `glossary_term`, its calculation stays in the model. Always
+use the `${CLAUDE_PLUGIN_ROOT}/…` path (the skill's cwd is the user's workspace),
+and route every write through this script — never improvise via MCP/Bash.
+
+## Phase 2 — Gate on approval, then write
+
+The write executes immediately (no dry-run). Present the diff, its target
+`qualifiedName`, and the value to be set; write **only** what the user approves.
+Then run `write` — it read-back-verifies and prints `{guid, status, verbatim_ok}`.
+To revert: `atlan_writeback.py delete --guid <g> --hard`.
+
+## Phase 3 — Report
+
+What landed (type, target, guid, value) and what didn't (declined, or the script's
+error verbatim). Persisted context is picked up by future builds/consumers on
+Atlan's sync cadence; it does not need to re-enter the current in-session model.

--- a/skills/update-to-atlan/atlan_writeback.py
+++ b/skills/update-to-atlan/atlan_writeback.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""atlan_writeback.py — write SQL-Intelligence context back to Atlan over raw REST.
+
+Stdlib only (json + urllib). Replaces the plugin's bundled atlan-sqlinsight write-MCP.
+
+Auth: reads ATLAN_BASE_URL (or ATLAN_API_URL) and ATLAN_API_KEY from the environment.
+      The API key value is NEVER printed or logged.
+
+Endpoints:
+  POST   /api/meta/entity/bulk          -> create/update
+  GET    /api/meta/entity/guid/{guid}   -> read-back (status + attributes)
+  DELETE /api/meta/entity/guid/{guid}   -> delete
+  POST   /api/meta/search/indexsearch   -> sweep by name prefix
+
+Five write types (all writes to Atlan go through this script — no MCP dependency):
+  filter         -> SqlInsightFilter          (QN = {columnQN}/filter/md5(operator))
+  relationship   -> SqlInsightJoin            (QN = {srcTableQN}/join/md5(joinedQN|sortedPairs|joinType))
+  popular_query  -> SqlInsightBusinessQuestion(QN = {tableQN}/question/md5(questionText))
+  description    -> update an asset's userDescription (resolves guid first; dbt `description` untouched)
+  glossary_term  -> create AtlasGlossaryTerm anchored to a glossary (+ optional column meanings edge)
+
+Canonical identity: every qualifiedName ends in a FULL 32-hex lowercase
+md5 of its own content, derived byte-for-byte the way the SQL-Intelligence miner and the
+UI author it (matching the miner's identity function and RFC-1321 md5 vectors). Reproducing it exactly is what makes a script-written row
+CONVERGE with the miner/UI-written row instead of duplicating it. Each write also
+dual-anchors by GUID via relationshipAttributes so the row renders on the asset page.
+
+CLI:
+  write  --type filter|relationship|popular_query|description|glossary_term --payload <json|@file>
+  verify --guid <g>
+  delete --guid <g> [--hard]   # --hard purges (true 404); default = soft (status=DELETED)
+  typedefs [--grep SqlInsight]   # dump SqlInsight* entity defs to confirm popular_query
+  sweep  --prefix ttd_           # find leftover test entities across the 3 types
+"""
+
+import json
+import os
+import sys
+import ssl
+import hashlib
+import urllib.request
+import urllib.error
+
+# ----- popular-query type confirmed against the tenant typedef -----
+# SqlInsightBusinessQuestion is a real entityDef (superType SqlInsight -> Catalog).
+# Confirmed attrs: sqlInsightBusinessQuestionText, sqlInsightBusinessQuestionCanonicalSQL.
+# Its dataset is anchored via the `sqlInsightDataset` RELATIONSHIP (by GUID), not a
+# qualifiedName string attribute.
+# NOTE: the qualifiedName segment used here was previously WRONG (/businessQuestion/
+# + a sha256[:16] hash). It is now aligned to the canonical identity:
+# {tableQN}/question/md5(questionText) with a full 32-hex md5, so a script-written
+# question converges with the miner/UI-written one.
+POPULAR_QUERY_TYPENAME = "SqlInsightBusinessQuestion"
+POPULAR_QUERY_VALIDATED = True
+
+# Atlan sits behind Cloudflare, which 1010-blocks the default Python-urllib
+# User-Agent. A browser-like UA is REQUIRED or every call 403s ("browser signature").
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+
+def _cfg():
+    base = os.environ.get("ATLAN_BASE_URL") or os.environ.get("ATLAN_API_URL")
+    key = os.environ.get("ATLAN_API_KEY")
+    if not base or not key:
+        sys.exit(
+            "ERROR: set ATLAN_BASE_URL (or ATLAN_API_URL) and ATLAN_API_KEY in env"
+        )
+    return base.rstrip("/"), key
+
+
+def _req(method, path, body=None):
+    base, key = _cfg()
+    url = base + path
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(url, data=data, method=method)
+    r.add_header("Authorization", "Bearer " + key)  # value never surfaced
+    r.add_header("Content-Type", "application/json")
+    r.add_header("Accept", "application/json")
+    r.add_header("User-Agent", _UA)  # REQUIRED: dodges Cloudflare 1010 bot-block
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(r, context=ctx, timeout=60) as resp:
+            raw = resp.read().decode()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, {"_raw": raw}
+
+
+def _md5(s):
+    """FULL 32-hex lowercase md5 (UTF-8), matching the miner's identity function byte-for-byte.
+    md5 here names a row and guards nothing — it is the miner's identity function."""
+    return hashlib.md5(s.encode("utf-8")).hexdigest()
+
+
+def _bare(qn):
+    """Bare column name = last '/'-segment of a column qualifiedName."""
+    return qn.rsplit("/", 1)[-1]
+
+
+def _anchor(entity, rel_map):
+    """Dual-anchor by GUID: attach relationshipAttributes for each non-null objectId.
+    Each value is an AtlasObjectId dict {'guid': ..., 'typeName': ...} or None."""
+    ra = {k: v for k, v in rel_map.items() if v}
+    if ra:
+        entity["relationshipAttributes"] = ra
+
+
+# --------------------------- builders ---------------------------
+
+
+def build_filter(p):
+    """SqlInsightFilter. Canonical QN = {columnQN}/filter/md5(operator).
+    payload: column_qn, operator, name;
+             optional: predicate_sql, dataset_qn, when_to_use, common_values (list),
+                       column_guid (objectId; else resolved for the sqlInsightColumn edge)."""
+    col = p["column_qn"]
+    op = p["operator"]
+    qn = p.get("qualifiedName") or f"{col}/filter/{_md5(op)}"
+    attrs = {
+        "qualifiedName": qn,
+        "name": p["name"],
+        "sqlInsightFilterColumnQualifiedName": col,
+        "sqlInsightFilterOperator": op,
+        "sqlInsightFilterPredicateSQL": p.get("predicate_sql", ""),
+        "sqlInsightFilterWhenToUse": p.get("when_to_use", ""),
+    }
+    if p.get("dataset_qn"):
+        attrs["sqlInsightFilterDatasetQualifiedName"] = p["dataset_qn"]
+    if p.get("common_values"):
+        attrs["sqlInsightFilterCommonValues"] = p["common_values"]
+    entity = {"typeName": "SqlInsightFilter", "attributes": attrs}
+    _anchor(entity, {"sqlInsightColumn": p.get("column_guid")})
+    return entity, ("qualifiedName", qn), ("sqlInsightFilterOperator", op)
+
+
+def build_relationship(p):
+    """SqlInsightJoin. Canonical QN = {srcTableQN}/join/md5("{joinedTableQN}|{sortedPairs}|{joinType}"),
+    where sortedPairs = ",".join(sorted("{srcColName}={joinedColName}")) over BARE column
+    names (last QN segment). The source table QN is the PREFIX, not part of the hash.
+    payload: source_dataset_qn, joined_dataset_qn, join_type,
+             column_pairs:[{source_column_qn, joined_column_qn}]; optional: name,
+             cardinality, source_dataset_guid / joined_dataset_guid (objectIds; else
+             resolved for the sqlInsightSourceDataset / sqlInsightJoinedDataset edges)."""
+    src = p["source_dataset_qn"]
+    jnd = p["joined_dataset_qn"]
+    jtype = p["join_type"]
+    sorted_pairs = ",".join(
+        sorted(
+            f"{cp.get('source_column') or _bare(cp['source_column_qn'])}="
+            f"{cp.get('joined_column') or _bare(cp['joined_column_qn'])}"
+            for cp in p["column_pairs"]
+        )
+    )
+    qn = p.get("qualifiedName") or f"{src}/join/{_md5(f'{jnd}|{sorted_pairs}|{jtype}')}"
+    pairs = []
+    for cp in p["column_pairs"]:
+        pairs.append(
+            {
+                "typeName": "SqlInsightJoinColumnPair",
+                "attributes": {
+                    "sqlInsightJoinColumnPairSourceColumnQualifiedName": cp[
+                        "source_column_qn"
+                    ],
+                    "sqlInsightJoinColumnPairJoinedColumnQualifiedName": cp[
+                        "joined_column_qn"
+                    ],
+                },
+            }
+        )
+    attrs = {
+        "qualifiedName": qn,
+        "name": p.get("name", f"join_{_md5(f'{jnd}|{sorted_pairs}|{jtype}')[:12]}"),
+        "sqlInsightJoinSourceDatasetQualifiedName": src,
+        "sqlInsightJoinJoinedDatasetQualifiedName": jnd,
+        "sqlInsightJoinType": jtype,
+        "sqlInsightJoinColumnPairs": pairs,
+    }
+    if p.get("cardinality"):
+        attrs["sqlInsightJoinCardinality"] = p["cardinality"]
+    entity = {"typeName": "SqlInsightJoin", "attributes": attrs}
+    _anchor(
+        entity,
+        {
+            "sqlInsightSourceDataset": p.get("source_dataset_guid"),
+            "sqlInsightJoinedDataset": p.get("joined_dataset_guid"),
+        },
+    )
+    return entity, ("qualifiedName", qn), ("sqlInsightJoinType", jtype)
+
+
+def build_popular_query(p):
+    """SqlInsightBusinessQuestion. Canonical QN = {tableQN}/question/md5(questionText).
+    Dataset is anchored via the sqlInsightDataset RELATIONSHIP (by GUID), not a QN attr.
+    payload: dataset_qn, question, sql; optional: name,
+             dataset_guid (objectId; else resolved for the sqlInsightDataset edge)."""
+    ds = p["dataset_qn"]
+    q = p["question"]
+    qn = p.get("qualifiedName") or f"{ds}/question/{_md5(q)}"
+    entity = {
+        "typeName": POPULAR_QUERY_TYPENAME,
+        "attributes": {
+            "qualifiedName": qn,
+            "name": p.get("name", q[:60]),
+            "sqlInsightBusinessQuestionText": q,
+            "sqlInsightBusinessQuestionCanonicalSQL": p["sql"],
+        },
+    }
+    _anchor(entity, {"sqlInsightDataset": p.get("dataset_guid")})
+    return entity, ("qualifiedName", qn), ("sqlInsightBusinessQuestionText", q)
+
+
+def build_description(p):
+    """Update an existing asset's userDescription (the governed prose the model
+    added). We resolve the asset's guid + typeName first and send them, so this is
+    an UPDATE to the existing entity, never a partial create (fixes the earlier
+    'guid Field required' error). The dbt-synced `description` is left untouched.
+    payload: asset_qn, user_description; optional asset_guid, asset_type."""
+    qn = p["asset_qn"]
+    if p.get("asset_guid") and p.get("asset_type"):
+        obj = {"guid": p["asset_guid"], "typeName": p["asset_type"]}
+    else:
+        obj = _resolve_objid(
+            qn, ("Column",) + _DATASET_TYPES
+        )  # asset types only, never a lineage Process
+    if not obj:
+        sys.exit(f"ERROR: could not resolve asset for description update: {qn}")
+    # Atlas requires `name` on an asset update; read the current name and preserve it
+    # (so we update userDescription without renaming the asset).
+    _, cur = op_verify(obj["guid"], quiet=True)
+    name = p.get("name") or cur.get("attributes", {}).get("name") or _bare(qn)
+    entity = {
+        "typeName": obj["typeName"],
+        "guid": obj["guid"],
+        "attributes": {
+            "qualifiedName": qn,
+            "name": name,
+            "userDescription": p["user_description"],
+        },
+    }
+    return entity, ("qualifiedName", qn), ("userDescription", p["user_description"])
+
+
+BUILDERS = {
+    "filter": build_filter,
+    "relationship": build_relationship,
+    "popular_query": build_popular_query,
+    "description": build_description,
+}
+
+
+# --------------------------- operations ---------------------------
+
+
+def _extract_guid(resp):
+    ga = resp.get("guidAssignments") or {}
+    if ga:
+        return list(ga.values())[0]
+    mut = resp.get("mutatedEntities") or {}
+    for k in ("CREATE", "UPDATE"):
+        if mut.get(k):
+            return mut[k][0].get("guid")
+    return None
+
+
+def _resolve_objid(qn, want_types=None):
+    """Resolve a qualifiedName to an AtlasObjectId {'guid','typeName'} via indexsearch.
+    Constrains to want_types (tuple of acceptable typeNames) so a QN also carried by a
+    lineage Process (or other non-asset) isn't picked over the real Table/Column — the
+    join/question/filter relationshipDefs require a specific end type, and a wrong-typed
+    objectId 400s. Returns None if nothing of the wanted type resolves."""
+    body = {
+        "dsl": {
+            "size": 10,
+            "query": {"bool": {"must": [{"term": {"qualifiedName": qn}}]}},
+        },
+        "attributes": ["qualifiedName"],
+    }
+    _, resp = _req("POST", "/api/meta/search/indexsearch", body)
+    ents = [e for e in (resp.get("entities") or []) if e.get("guid")]
+    if want_types:
+        ents = [e for e in ents if e.get("typeName") in want_types]
+    for e in ents:
+        return {"guid": e["guid"], "typeName": e.get("typeName")}
+    return None
+
+
+# a "dataset" anchor may be any of these SQL asset types (never a lineage Process)
+_DATASET_TYPES = ("Table", "View", "MaterialisedView", "SnowflakeDynamicTable")
+# qualifiedName payload key -> objectId payload key + acceptable typeNames for the anchor
+_ANCHOR_RESOLVE = {
+    "filter": [("column_qn", "column_guid", ("Column",))],
+    "relationship": [
+        ("source_dataset_qn", "source_dataset_guid", _DATASET_TYPES),
+        ("joined_dataset_qn", "joined_dataset_guid", _DATASET_TYPES),
+    ],
+    "popular_query": [("dataset_qn", "dataset_guid", _DATASET_TYPES)],
+}
+
+
+def op_glossary_term(payload):
+    """Create an AtlasGlossaryTerm via Atlan's dedicated glossary endpoint (which
+    auto-assigns the term's qualifiedName — the raw entity/bulk API rejects a term
+    without one). Optionally bind the term to a column (the `meanings` edge).
+    payload: name, glossary_qn (or glossary_guid); optional description,
+             assign_column_qn."""
+    if payload.get("glossary_guid"):
+        gguid = payload["glossary_guid"]
+    else:
+        gobj = _resolve_objid(payload["glossary_qn"], ("AtlasGlossary",))
+        if not gobj:
+            sys.exit(f"ERROR: could not resolve glossary: {payload.get('glossary_qn')}")
+        gguid = gobj["guid"]
+    body = {"name": payload["name"], "anchor": {"glossaryGuid": gguid}}
+    if payload.get("description"):
+        body["longDescription"] = payload["description"]
+    status, resp = _req("POST", "/api/meta/glossary/term", body)
+    guid = resp.get("guid")
+    out = {"http_status": status, "guid": guid, "glossary_guid": gguid}
+    if guid:
+        _, ver = op_verify(guid, quiet=True)
+        out["status"] = ver.get("status")
+        out["qualifiedName"] = ver.get("attributes", {}).get("qualifiedName")
+        out["verbatim_ok"] = ver.get("attributes", {}).get("name") == payload["name"]
+        if payload.get("assign_column_qn"):
+            col = _resolve_objid(payload["assign_column_qn"], ("Column",))
+            if col:
+                # APPEND to the column's existing meanings (bulk `meanings` is set-replace,
+                # so read current terms first and merge — never drop an existing term).
+                _, cver = op_verify(col["guid"], quiet=True)
+                existing = [
+                    {
+                        "guid": m["guid"],
+                        "typeName": m.get("typeName", "AtlasGlossaryTerm"),
+                    }
+                    for m in (
+                        cver.get("relationshipAttributes", {}).get("meanings") or []
+                    )
+                    if m.get("guid")
+                ]
+                merged = existing + (
+                    [{"guid": guid, "typeName": "AtlasGlossaryTerm"}]
+                    if guid not in [m["guid"] for m in existing]
+                    else []
+                )
+                assign = {
+                    "typeName": col["typeName"],
+                    "guid": col["guid"],
+                    "attributes": {"qualifiedName": payload["assign_column_qn"]},
+                    "relationshipAttributes": {"meanings": merged},
+                }
+                as_status, _ = _req(
+                    "POST", "/api/meta/entity/bulk", {"entities": [assign]}
+                )
+                out["assigned_to_column"] = {
+                    "qn": payload["assign_column_qn"],
+                    "ok": as_status in (200, 204),
+                    "meanings_after": len(merged),
+                }
+            else:
+                out["assigned_to_column"] = {
+                    "qn": payload["assign_column_qn"],
+                    "error": "column not resolved",
+                }
+    else:
+        out["error"] = resp
+    print(json.dumps(out, indent=2))
+    return out
+
+
+def op_write(type_, payload):
+    if type_ == "glossary_term":
+        return op_glossary_term(payload)
+    if type_ == "popular_query" and not POPULAR_QUERY_VALIDATED:
+        sys.stderr.write(
+            "WARNING: popular_query typeName/attrs are UNVALIDATED — confirm via "
+            "`typedefs` against your Atlan tenant before trusting this write.\n"
+        )
+    # Dual-anchoring: resolve each anchor QN -> objectId unless already supplied.
+    for qn_key, guid_key, want_types in _ANCHOR_RESOLVE.get(type_, []):
+        if guid_key not in payload and payload.get(qn_key):
+            payload[guid_key] = _resolve_objid(payload[qn_key], want_types)
+    entity, qn_key, verbatim_key = BUILDERS[type_](payload)
+    request_body = {"entities": [entity]}
+    status, resp = _req("POST", "/api/meta/entity/bulk", request_body)
+    # _extract_guid returns None on an idempotent (no-change) update; fall back to the
+    # guid the builder already resolved (e.g. `description` updates) so verify still runs.
+    guid = _extract_guid(resp) or entity.get("guid")
+    out = {
+        "http_status": status,
+        "guid": guid,
+        # glossary terms get an Atlan-assigned qualifiedName; filled from read-back below
+        "qualifiedName": entity["attributes"].get("qualifiedName"),
+    }
+    out["relationshipAttributes_sent"] = list(
+        (entity.get("relationshipAttributes") or {}).keys()
+    )
+    if guid:
+        vs, ver = op_verify(guid, quiet=True)
+        out["status"] = ver.get("status")
+        out["verbatim_ok"] = (
+            ver.get("attributes", {}).get(verbatim_key[0]) == verbatim_key[1]
+        )
+        if not out["qualifiedName"]:
+            out["qualifiedName"] = ver.get("attributes", {}).get("qualifiedName")
+        # Edge is populated when the read-back relationshipAttributes carry a guid.
+        rel = ver.get("relationshipAttributes", {}) or {}
+        out["edges_populated"] = {
+            k: bool((rel.get(k) or {}).get("guid"))
+            for k in (entity.get("relationshipAttributes") or {})
+        }
+    else:
+        out["error"] = resp
+    # Full request+response evidence dump when WRITEBACK_DEBUG=<path> is set.
+    dbg = os.environ.get("WRITEBACK_DEBUG")
+    if dbg:
+        with open(dbg, "w") as f:
+            json.dump(
+                {
+                    "type": type_,
+                    "request": request_body,
+                    "create_http_status": status,
+                    "create_response": resp,
+                    "summary": out,
+                },
+                f,
+                indent=2,
+            )
+    print(json.dumps(out, indent=2))
+    return out
+
+
+def op_verify(guid, quiet=False):
+    status, resp = _req("GET", f"/api/meta/entity/guid/{guid}")
+    ent = resp.get("entity") or {}
+    info = {
+        "http_status": status,
+        "guid": guid,
+        "status": ent.get("status"),
+        "typeName": ent.get("typeName"),
+        "attributes": ent.get("attributes", {}),
+        "relationshipAttributes": ent.get("relationshipAttributes", {}),
+    }
+    if not quiet:
+        print(json.dumps(info, indent=2))
+    return status, info
+
+
+def op_delete(guid, hard=False):
+    # Default (soft) delete flips status ACTIVE->DELETED but the entity-GET still
+    # resolves (HTTP 200, status=DELETED) — this tenant retains soft-deleted rows.
+    # --hard uses deleteType=PURGE so a subsequent GET is a true 404
+    # (ATLAS-404-00-005). PURGE works whether the entity is ACTIVE or already
+    # soft-DELETED; deleteType=HARD is a no-op on an already-soft-deleted row.
+    path = f"/api/meta/entity/guid/{guid}"
+    if hard:
+        path += "?deleteType=PURGE"
+    status, resp = _req("DELETE", path)
+    print(
+        json.dumps(
+            {"http_status": status, "guid": guid, "hard": hard, "response": resp},
+            indent=2,
+        )
+    )
+
+
+def op_typedefs(grep):
+    # NB: the ?type=entitydef filter can return empty on some tenants — fetch all
+    # typedefs and filter entityDefs client-side.
+    status, resp = _req("GET", "/api/meta/types/typedefs")
+    defs = resp.get("entityDefs", [])
+    hits = [d for d in defs if grep.lower() in d.get("name", "").lower()]
+    for d in hits:
+        print(d["name"], "->", [a["name"] for a in d.get("attributeDefs", [])])
+    if not hits:
+        print(f"(no entity typedef matching {grep!r}) http={status}")
+
+
+def op_sweep(prefix):
+    types = ["SqlInsightFilter", "SqlInsightJoin", POPULAR_QUERY_TYPENAME]
+    total = 0
+    for t in types:
+        body = {
+            "dsl": {
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"__typeName.keyword": t}},
+                            {"prefix": {"name.keyword": prefix}},
+                        ]
+                    }
+                }
+            }
+        }
+        status, resp = _req("POST", "/api/meta/search/indexsearch", body)
+        ents = resp.get("entities", []) or []
+        active = [e for e in ents if e.get("status") == "ACTIVE"]
+        total += len(active)
+        print(f"{t}: {len(active)} ACTIVE with name prefix {prefix!r}")
+        for e in active:
+            print("  ", e.get("guid"), e.get("attributes", {}).get("name"))
+    print(f"TOTAL active test entities: {total}")
+
+
+def _load_payload(arg):
+    if arg.startswith("@"):
+        with open(arg[1:]) as f:
+            return json.load(f)
+    return json.loads(arg)
+
+
+def main(argv):
+    if not argv:
+        sys.exit(__doc__)
+    cmd = argv[0]
+    args = dict(zip(argv[1::2], argv[2::2]))
+    if cmd == "write":
+        op_write(args["--type"], _load_payload(args["--payload"]))
+    elif cmd == "verify":
+        op_verify(args["--guid"])
+    elif cmd == "delete":
+        op_delete(args["--guid"], hard=("--hard" in argv))
+    elif cmd == "typedefs":
+        op_typedefs(args.get("--grep", "SqlInsight"))
+    elif cmd == "sweep":
+        op_sweep(args.get("--prefix", "ttd_"))
+    else:
+        sys.exit(f"unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/skills/update-to-atlan/atlan_writeback.py
+++ b/skills/update-to-atlan/atlan_writeback.py
@@ -142,8 +142,15 @@ def build_filter(p):
 
 def build_relationship(p):
     """SqlInsightJoin. Canonical QN = {srcTableQN}/join/md5("{joinedTableQN}|{sortedPairs}|{joinType}"),
-    where sortedPairs = ",".join(sorted("{srcColName}={joinedColName}")) over BARE column
-    names (last QN segment). The source table QN is the PREFIX, not part of the hash.
+    where sortedPairs joins BARE "{srcColName}={joinedColName}" with commas ORDERED BY
+    THE SOURCE COLUMN ONLY (not by the formatted pair string). That matches the miner --
+    `STRING_AGG(cp.source || '=' || cp.joined, ',' ORDER BY cp.source)` in the
+    sql_intelligence DAG -- and pyatlan's SqlInsightJoin.generate_qualified_name. Sorting
+    the formatted strings instead diverges whenever one source column is a prefix of
+    another followed by a digit (ORDER_ID / ORDER_ID2), because '=' is 0x3D and digits are
+    0x30-0x39; the md5 then differs and the write DUPLICATES the miner's row instead of
+    converging on it. The sort is stable, so pairs sharing a source column keep the
+    caller's order, as pyatlan does. The source table QN is the PREFIX, not part of the hash.
     payload: source_dataset_qn, joined_dataset_qn, join_type,
              column_pairs:[{source_column_qn, joined_column_qn}]; optional: name,
              cardinality, source_dataset_guid / joined_dataset_guid (objectIds; else
@@ -151,12 +158,16 @@ def build_relationship(p):
     src = p["source_dataset_qn"]
     jnd = p["joined_dataset_qn"]
     jtype = p["join_type"]
-    sorted_pairs = ",".join(
-        sorted(
-            f"{cp.get('source_column') or _bare(cp['source_column_qn'])}="
-            f"{cp.get('joined_column') or _bare(cp['joined_column_qn'])}"
-            for cp in p["column_pairs"]
+    _bare_pairs = [
+        (
+            cp.get("source_column") or _bare(cp["source_column_qn"]),
+            cp.get("joined_column") or _bare(cp["joined_column_qn"]),
         )
+        for cp in p["column_pairs"]
+    ]
+    sorted_pairs = ",".join(
+        f"{src_col}={jnd_col}"
+        for src_col, jnd_col in sorted(_bare_pairs, key=lambda pair: pair[0])
     )
     qn = p.get("qualifiedName") or f"{src}/join/{_md5(f'{jnd}|{sorted_pairs}|{jtype}')}"
     pairs = []


### PR DESCRIPTION
## Summary

A self-contained talk-to-data loop: build a governed Snowflake Cortex semantic view from Atlan context, then close the eval loop by diagnosing failures and writing the proven fix back to Atlan. No LLM authoring in the build; the LLM only diagnoses.

Three skills, each self-contained with its script co-located:

- **build-view** — build the model from Atlan context via the governed `/semantic-model/build` endpoint (`build_model.py`). No LLM authoring.
- **assess-gap** — diagnose why the view fails its evals against a fixed gap taxonomy, reading only the safe eval projection (never the golden answers); one grounded, typed fix per gap.
- **update-to-atlan** — persist an approved, typed fix (description / glossary_term / filter / relationship / popular_query) via `atlan_writeback.py`; approval-gated, read-back verified.

## What ships

```
skills/build-view/{SKILL.md, build_model.py}
skills/assess-gap/SKILL.md
skills/update-to-atlan/{SKILL.md, atlan_writeback.py}
```

Config: `$ATLAN_BUILD_ENDPOINT` (your tenant's `/semantic-model/build`) and `$ATLAN_API_KEY`. Skills reference no MCP tools, so the skill-tool validator passes.

## Note

`build-view` overlaps `build-semantic-view` (#241) on the build step. Happy to reconcile to one build skill; the net-new here is the eval to fix to write-back loop on top of the build.

Claude Code only for now (skills are auto-discovered from `skills/`); the Cursor and Codex plugins remain MCP-only.

Generated with [Claude Code](https://claude.com/claude-code)
