### PR TITLE
CTX-488 | feat(skills): build-semantic-view and update-to-atlan, tool-based

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "atlan": {
       "type": "http",
-      "url": "https://mcp.atlan.com/mcp"
+      "url": "https://mcp.atlan.com/mcp",
+      "timeout": 1800000
     }
   }
 }

--- a/skills/build-semantic-view/SKILL.md
+++ b/skills/build-semantic-view/SKILL.md
@@ -40,6 +40,11 @@ Create the directory if it is missing. Tell the user the path.
   space also needs a Databricks metric view deployed first, so build `engine=databricks`
   over the same tables as well and say the metric view is deployed before the space.
 
+If `content` comes back empty there is no file to write, and `summary` says why. The
+common case is asking for `dbt` over tables no dbt model manages: dbt semantic models need
+dbt-materialised tables, and the same tables build fine for cortex and databricks. Relay
+the reason and offer another engine rather than retrying the same one.
+
 Say once, at the end, that nothing was saved to Atlan and this file is theirs to commit.
 
 ## When the tool is not available

--- a/skills/build-semantic-view/SKILL.md
+++ b/skills/build-semantic-view/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: build-semantic-view
+description: Build a semantic model for Snowflake Cortex Analyst, a Databricks metric view, a Databricks Genie space or dbt MetricFlow from Atlan-governed context, and put it in this repository. Use when someone asks to build a semantic view, a semantic model, a Cortex model, a metric view, a Genie space config or a dbt semantic model for a set of tables.
+---
+
+# Build a semantic view
+
+The `build_semantic_view_tool` does the work and its own description carries the full
+sequence. This skill adds only what a terminal can do that a chat window cannot: ask the
+question as a real prompt, and write the file where the person is working.
+
+## Getting the tables
+
+Table names must be full Atlan qualifiedNames including the connection prefix, like
+`default/snowflake/1712345678/ANALYTICS/SALES/ORDERS`. The short `DB/SCHEMA/TABLE` form is
+not found. If you have names but not qualifiedNames, use `search_assets_tool` to resolve
+them first. Never invent one.
+
+## Confirming before you spend the minutes
+
+Call `build_semantic_view_tool` with `dry_run=true` first. Put its answer to the user with
+**AskUserQuestion**, not as prose, so they can pick:
+
+- **Add the suggested tables** when `suggested_tables` is non-empty. Say plainly that a
+  relationship needs both of its tables in the model, so without them the model will have
+  no relationships at all.
+- **Build the list as it stands.**
+
+Then call again with `dry_run=false` and the confirmed list. Relay `summary` verbatim, and
+report progress while you poll.
+
+## Where the file goes
+
+Write the returned `content` to `./semantic_models/<name>.yaml`, or `.json` for `genie`.
+Create the directory if it is missing. Tell the user the path.
+
+- **dbt** returns several documents in one stream, separated by `# path:` banners. Split on
+  those banners and write each to the path its banner names.
+- **genie** returns JSON in which `_partial: true` is expected and is not a problem. A Genie
+  space also needs a Databricks metric view deployed first, so build `engine=databricks`
+  over the same tables as well and say the metric view is deployed before the space.
+
+Say once, at the end, that nothing was saved to Atlan and this file is theirs to commit.
+
+## When the tool is not available
+
+If the tool is missing or reports that the capability is not enabled, say so and stop. Do
+not fall back to writing a semantic model by hand: every element of a real one comes from
+Atlan's catalog, and an invented one looks identical and is wrong.
+
+## Fixing what is missing
+
+When the summary reports undescribed columns or no relationships, the fix belongs in Atlan
+so every future build inherits it. Use the **update-to-atlan** skill.

--- a/skills/update-to-atlan/SKILL.md
+++ b/skills/update-to-atlan/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: update-to-atlan
+description: Persist a context fix back to Atlan so every future semantic-model build and every other consumer reuses it - a join, a named filter, a business question with its SQL, an asset description, or a glossary term. Use when someone asks to write a fix back to Atlan, persist context, push a join or filter to Atlan, or save a definition.
+---
+
+# Write a context fix back to Atlan
+
+A fix found while reading a model is worth making once. Writing it back is what makes the
+next build, and every other consumer, inherit it.
+
+## Which tool
+
+| The fix | Tool |
+|---|---|
+| a join between two tables | `create_sql_insight` with `kind="join"` |
+| a named filter on a column | `create_sql_insight` with `kind="filter"` |
+| a business question and the SQL that answers it | `create_sql_insight` with `kind="question"` |
+| an asset's description | `update_assets_tool` |
+| a business term | `create_glossary_terms` |
+
+A metric is not a write type of its own. Persist what it means as a glossary term; its
+calculation belongs in the semantic model.
+
+## The approval gate
+
+`create_sql_insight` defaults to `mode="propose"`. Call it that way first, show the user
+the preview, and wait for them to say yes before calling again with `mode="execute"`.
+
+**The permission prompt your client shows for running a tool is not that approval.** It
+asks whether you may call the tool; it does not ask whether this content should be written
+to the company's catalog. Ask separately, in words.
+
+The preview reports an `action`. Say which one it is:
+
+- **create** - nothing with this identity exists yet.
+- **update** - this identity already exists and the write will land on it. Atlan derives
+  the identity from the content, so this converges with what is already there rather than
+  making a duplicate, but it is still an edit to an existing row.
+- **revive** - it exists but was archived, and writing will bring it back.
+
+## After the write
+
+The result carries `guid`, `qualified_name`, `status` and `verbatim_ok`. Report what
+landed. If `verbatim_ok` is false, what came back is not what was sent: say so rather than
+reporting success.
+
+To undo one, use `manage_asset_lifecycle_tool` with `PURGE` on the guid. An archive alone
+leaves the row resolvable.
+
+Write one fix per call. If several were found, take them one at a time so each gets its own
+approval.

--- a/skills/update-to-atlan/SKILL.md
+++ b/skills/update-to-atlan/SKILL.md
@@ -44,8 +44,10 @@ The result carries `guid`, `qualified_name`, `status` and `verbatim_ok`. Report 
 landed. If `verbatim_ok` is false, what came back is not what was sent: say so rather than
 reporting success.
 
-To undo one, use `manage_asset_lifecycle_tool` with `PURGE` on the guid. An archive alone
-leaves the row resolvable.
+To undo one, use `manage_asset_lifecycle_tool` with `operation="PURGE"` and
+`mode="execute"` on the guid. Without `mode="execute"` it returns a preview and removes
+nothing, which reads like success. Purge rather than archive: an archived row still
+resolves, so the identity stays taken and the next write updates it instead of creating.
 
 Write one fix per call. If several were found, take them one at a time so each gets its own
 approval.


### PR DESCRIPTION
Part of **CTX-488**. Lands with two others, same key:
- `atlanhq/wisdom` [#2119](https://github.com/atlanhq/wisdom/pull/2119) — the async build, `dry_run` and `summary`
- `atlanhq/agent-toolkit-internal` [#560](https://github.com/atlanhq/agent-toolkit-internal/pull/560) — the `build_semantic_view_tool` and `create_sql_insight` these route to

**Depends on #560 shipping to hosted.** Both tool names are already registered there on that branch; until it deploys, the tool-name check in #238 will not know them.

## The rule these two skills follow

Everything that decides what the user actually **gets** lives in the tools and their descriptions, because that is what reaches everyone. This plugin ships skills, but `cursor-plugin/.cursor-plugin/plugin.json` and the Codex manifest in this same repository carry an MCP URL and nothing else, and most people using Atlan through MCP have no plugin at all.

So a skill here may make Claude Code nicer. It may not make it **better** — otherwise a user without one gets a worse model and has no way to know it.

## `build-semantic-view` (54 lines)

Adds three things and no rules:
- the confirmation asked as a real **AskUserQuestion** prompt rather than prose
- a standard path, `./semantic_models/<name>.yaml`
- the file-splitting a client with a filesystem can do for dbt's multi-document output

The sequence itself, and every sentence about what the model contains and lacks, comes from the tool and from wisdom's `summary`.

## `update-to-atlan` (51 lines)

Routes a fix to the right tool and holds the approval gate. It says the thing a permission prompt cannot: **your client asking whether it may call a tool is not the same as a person agreeing that this content should be written to the company's catalog.**

It also explains what the preview's `action` means, because "update" on a derived identity is convergence with what Atlan already mined rather than a duplicate, and a reader has no way to know that.

## Also

The plugin's MCP entry gets a long timeout as belt and braces. It should not matter now that the build starts and polls instead of holding a request open, but a client that ignores the poll and waits should not be the thing that breaks.

## Verification

Both files pass #238's tool-name checker with **0 bad references** against the 52-tool surface from #560.

One thing worth doing on the #238 branch before it merges: its `scripts/known_tools.json` lists 46 tools and the current surface has 50. It still names `benchmark_query_tool`, `manage_context_repo_tool` and `search_tool`, which no longer exist, and is missing `fluent_search`, `fluent_search_schema`, `get_context_tool`, `get_metric_tool` and the three `knowledge_upload_*` tools. A skill naming any of those seven would fail the check wrongly. Regenerating it from the MCP server's committed surface baseline, which the script's own docstring explains how to do, fixes both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
